### PR TITLE
index ClientPolicies and bind them to OutboundServers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,7 @@ dependencies = [
  "client-policy-k8s-api",
  "comfy-table",
  "futures",
+ "humantime",
  "ipnet",
  "k8s-gateway-api",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
  "parking_lot",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "3", default-features = false, features = [
     "std",
 ] }
 futures = { version = "0.3", default-features = false }
+humantime = "2"
 ipnet = "2"
 k8s-openapi = { version = "0.15", features = ["v1_20"] }
 k8s-gateway-api = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,22 @@ publish = false
 ahash = "0.7"
 anyhow = "1"
 chrono = "0.4"
+comfy-table = "6.1.0"
 clap = { version = "3", default-features = false, features = [
     "derive",
     "env",
     "std",
 ] }
+client-policy-k8s-api = { path = "./k8s/api" }
 futures = { version = "0.3", default-features = false }
 humantime = "2"
 ipnet = "2"
 k8s-openapi = { version = "0.15", features = ["v1_20"] }
 k8s-gateway-api = "0.6"
 parking_lot = "0.12"
+serde = "1"
 thiserror = "1"
 tracing = "0.1"
-comfy-table = "6.1.0"
-client-policy-k8s-api = { path = "./k8s/api" }
 
 [dependencies.kube]
 version = "0.74"

--- a/examples/clientpolicy.yml
+++ b/examples/clientpolicy.yml
@@ -4,9 +4,10 @@ metadata:
   name: authors-get
 spec:
   targetRef:
-    name: authors-get
+    name: authors-get-route
     kind: HTTPRoute
     group: policy.linkerd.io
+    namespace: booksapp
   failureClassification:
     statuses:
       - "401"

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -97,7 +97,7 @@ impl TryFrom<k8s::ClientPolicy> for Spec {
 impl Target {
     fn try_from_target_ref(ns: String, target: NamespacedTargetRef) -> Result<Self, Error> {
         match target {
-            t if t.targets_kind::<HttpRoute>() => Ok(Target::Server {
+            t if t.targets_kind::<policy::Server>() => Ok(Target::Server {
                 name: t.name,
                 namespace: t.namespace.unwrap_or(ns),
             }),

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -1,0 +1,92 @@
+use crate::k8s::policy::{self, HttpRoute, NamespacedTargetRef, Server};
+use anyhow::{Context, Error};
+use client_policy_k8s_api::client_policy as k8s;
+pub use k8s::FailureClassification;
+use std::{convert::TryFrom, time::Duration};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClientPolicy {
+    pub target: Target,
+    pub failure_classification: FailureClassification,
+    pub filters: Vec<Filter>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Target {
+    /// This policy's parent ref is a `Server`.
+    Server {
+        name: String,
+        namespace: Option<String>,
+    },
+
+    /// This policy's parent ref is an `HTTPRoute`.
+    HttpRoute {
+        name: String,
+        namespace: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Filter {
+    Timeout(Duration),
+}
+
+// === impl ClientPolicy ===
+
+impl TryFrom<k8s::ClientPolicy> for ClientPolicy {
+    type Error = Error;
+
+    fn try_from(policy: k8s::ClientPolicy) -> Result<Self, Self::Error> {
+        let target = Target::try_from(policy.spec.target_ref)?;
+        // XXX(eliza): it would be good to validate that these are real http
+        // status ranges, but "meh".
+        let failure_classification = policy.spec.failure_classification;
+        let filters = policy
+            .spec
+            .filters
+            .into_iter()
+            .map(Filter::try_from)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            target,
+            failure_classification,
+            filters,
+        })
+    }
+}
+
+// === impl Target ===
+
+impl TryFrom<NamespacedTargetRef> for Target {
+    type Error = Error;
+
+    fn try_from(target_ref: NamespacedTargetRef) -> Result<Self, Self::Error> {
+        match target_ref {
+            t if t.targets_kind::<Server>() => Ok(Target::Server {
+                name: t.name,
+                namespace: t.namespace,
+            }),
+            t if t.targets_kind::<HttpRoute>() => Ok(Target::HttpRoute {
+                name: t.name,
+                namespace: t.namespace,
+            }),
+            _ => Err(anyhow::anyhow!(
+                "a ClientPolicy must target either a Server or an HTTPRoute"
+            )),
+        }
+    }
+}
+
+// === impl Filter ===
+
+impl TryFrom<k8s::ClientPolicyFilter> for Filter {
+    type Error = Error;
+
+    fn try_from(filter: k8s::ClientPolicyFilter) -> Result<Self, Self::Error> {
+        match filter {
+            k8s::ClientPolicyFilter::Timeout { timeout } => humantime::parse_duration(&timeout)
+                .map(Filter::Timeout)
+                .with_context(|| format!("invalid timeout duration '{timeout}'")),
+        }
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use ahash::{AHashMap, AHashSet};
 use anyhow::Result;
+use client_policy_k8s_api::client_policy::{self, ClientPolicy};
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
 use std::{
@@ -399,6 +400,22 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for LockedIn
     fn delete(&mut self, ns: String, name: String) {
         let _span = tracing::info_span!("delete", %ns, %name).entered();
         self.ns_with_reindex(ns, |ns| ns.policies.http_routes.remove(&name).is_some())
+    }
+}
+
+impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
+    fn apply(&mut self, policy: ClientPolicy) {
+        todo!("eliza")
+    }
+
+    fn reset(&mut self, routes: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
+        let _span = tracing::info_span!("reset").entered();
+        todo!("eliza")
+    }
+
+    #[tracing::instrument(skip(self), fields(%ns, %name))]
+    fn delete(&mut self, ns: String, name: String) {
+        todo!("eliza")
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core,
+    client_policy, core,
     k8s::{self, ResourceExt},
     pod,
     route::{OutboundHttpRoute, OutboundRouteBinding},
@@ -8,7 +8,8 @@ use crate::{
 };
 use ahash::{AHashMap, AHashSet};
 use anyhow::Result;
-use client_policy_k8s_api::client_policy::{self, ClientPolicy};
+use client_policy_k8s_api::client_policy::ClientPolicy;
+use k8s::policy;
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
 use std::{
@@ -35,14 +36,30 @@ pub struct Index {
 struct LockedIndex {
     cluster_info: Arc<ClusterInfo>,
     namespaces: AHashMap<String, Namespace>,
+    client_policies: ClientPolicyNsIndex,
     servers_by_addr: ServersByAddr,
     changed: Instant,
 }
 
 type ServersByAddr = HashMap<SocketAddr, watch::Receiver<OutboundServer>>;
 
+/// Holds all `ClientPolicy` and `ClientPolicyBinding` indices by-namespace.
+///
+/// This is separate from `NamespaceIndex` because client policies may reference
+/// target resources across namespaces.
+#[derive(Debug, Default)]
+struct ClientPolicyNsIndex {
+    by_ns: AHashMap<String, ClientPolicyIndex>,
+}
+
+#[derive(Debug, Default)]
+struct ClientPolicyIndex {
+    policies: AHashMap<String, client_policy::Spec>,
+}
+
 #[derive(Debug)]
 struct Namespace {
+    name: Arc<String>,
     pods: AHashMap<String, Pod>,
     policies: PolicyIndex,
 }
@@ -58,6 +75,7 @@ struct Pod {
 
 #[derive(Debug)]
 struct PolicyIndex {
+    namespace: Arc<String>,
     cluster_info: Arc<ClusterInfo>,
     servers: AHashMap<String, Server>,
     http_routes: AHashMap<String, OutboundRouteBinding>,
@@ -92,6 +110,7 @@ impl Index {
                 namespaces: AHashMap::new(),
                 servers_by_addr: HashMap::new(),
                 changed: Instant::now(),
+                client_policies: ClientPolicyNsIndex::default(),
             })),
         }
     }
@@ -126,6 +145,14 @@ impl Index {
     pub fn dump_index(&self, every: Duration) -> tokio::task::JoinHandle<()> {
         tracing::debug!(?every, "dumping index changes");
         let index = self.index.clone();
+
+        fn route_name(route: &core::InboundHttpRouteRef) -> &str {
+            match route {
+                core::InboundHttpRouteRef::Default(name) => name,
+                core::InboundHttpRouteRef::Linkerd(name) => name.as_str(),
+            }
+        }
+
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(every);
             let mut last_changed = index.read().changed;
@@ -139,7 +166,7 @@ impl Index {
                         .load_preset(UTF8_FULL)
                         .set_content_arrangement(ContentArrangement::Dynamic)
                         .set_header(Row::from(vec![
-                            "ADDRESS", "SERVER", "KIND", "PROTOCOL", "ROUTES",
+                            "ADDRESS", "SERVER", "KIND", "PROTOCOL", "ROUTES", "POLICIES",
                         ]));
                     for (addr, srv) in &index.servers_by_addr {
                         let srv = srv.borrow();
@@ -150,10 +177,18 @@ impl Index {
                         let route_list = srv
                             .http_routes
                             .keys()
-                            .map(|route| match route {
-                                core::InboundHttpRouteRef::Default(name) => name,
-                                core::InboundHttpRouteRef::Linkerd(name) => name.as_str(),
-                            })
+                            .map(route_name)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let policy_list = srv
+                            .client_policy
+                            .iter()
+                            .map(|policy| format!("server: {}", policy.name))
+                            .chain(srv.http_routes.iter().filter_map(|(route_ref, route)| {
+                                let policy = route.client_policy.as_ref()?;
+                                let route_name = route_name(route_ref);
+                                Some(format!("routes[{route_name}]: {}", policy.name))
+                            }))
                             .collect::<Vec<_>>()
                             .join("\n");
 
@@ -163,9 +198,39 @@ impl Index {
                             Cell::new(kind),
                             Cell::new(&format!("{:?}", srv.protocol)),
                             Cell::new(route_list),
+                            Cell::new(policy_list),
                         ]));
                     }
-                    println!("{srvs_by_addr}");
+
+                    let mut policies = Table::new();
+                    policies
+                        .load_preset(UTF8_FULL)
+                        .set_content_arrangement(ContentArrangement::Dynamic)
+                        .set_header(Row::from(vec![
+                            "NAMESPACE",
+                            "POLICY",
+                            "FAILURE CLASSIFICATION",
+                            "FILTERS",
+                        ]));
+                    let policies_by_ns =
+                        index
+                            .client_policies
+                            .by_ns
+                            .iter()
+                            .flat_map(|(ns_name, ns)| {
+                                ns.policies
+                                    .iter()
+                                    .map(move |(name, policy)| (ns_name, name, policy))
+                            });
+                    for (ns, name, policy) in policies_by_ns {
+                        policies.add_row(Row::from(vec![
+                            Cell::new(&ns),
+                            Cell::new(name),
+                            Cell::new(&format!("{:?}", policy.failure_classification)),
+                            Cell::new(format!("{:?}", policy.filters)),
+                        ]));
+                    }
+                    println!("{srvs_by_addr}\n{policies}");
                     last_changed = index.changed;
                 }
             }
@@ -180,7 +245,8 @@ impl LockedIndex {
                 if ns.get().pods.is_empty() {
                     ns.remove();
                 } else {
-                    ns.get_mut().reindex_servers(&mut self.servers_by_addr);
+                    ns.get_mut()
+                        .reindex_servers(&mut self.servers_by_addr, &self.client_policies);
                 }
 
                 self.changed = Instant::now();
@@ -201,10 +267,10 @@ impl LockedIndex {
     ) {
         let ns = self
             .namespaces
-            .entry(namespace)
-            .or_insert_with(|| Namespace::new(&self.cluster_info));
+            .entry(namespace.clone())
+            .or_insert_with(|| Namespace::new(namespace, &self.cluster_info));
         if f(ns) {
-            ns.reindex_servers(&mut self.servers_by_addr);
+            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
 
             self.changed = Instant::now();
         }
@@ -219,9 +285,11 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
 
         let ns = self
             .namespaces
-            .entry(ns)
-            .or_insert_with(|| Namespace::new(&self.cluster_info));
-        if let Err(error) = ns.update_pod(name, pod, &mut self.servers_by_addr) {
+            .entry(ns.clone())
+            .or_insert_with(|| Namespace::new(ns, &self.cluster_info));
+        if let Err(error) =
+            ns.update_pod(name, pod, &self.client_policies, &mut self.servers_by_addr)
+        {
             tracing::error!(%error, "illegal pod update");
         }
     }
@@ -248,6 +316,17 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
             self.changed = Instant::now();
         } else {
             tracing::debug!("tried to delete a pod in a namespace that does not exist!");
+        }
+    }
+}
+
+// === impl LockedIndex ===
+
+impl LockedIndex {
+    fn reindex_all(&mut self) {
+        tracing::debug!("Reindexing all namespaces");
+        for ns in self.namespaces.values_mut() {
+            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
         }
     }
 }
@@ -405,7 +484,22 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for LockedIn
 
 impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
     fn apply(&mut self, policy: ClientPolicy) {
-        todo!("eliza")
+        let ns = policy
+            .namespace()
+            .expect("ClientPolicy must have a namespace");
+        let name = policy.name_unchecked();
+        let _span = tracing::info_span!("apply", %ns, %name).entered();
+        let spec = match client_policy::Spec::try_from(policy) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tracing::warn!(%error, "invalid ClientPolicy");
+                return;
+            }
+        };
+
+        if self.client_policies.update_policy(ns, name, spec) {
+            self.reindex_all()
+        }
     }
 
     fn reset(&mut self, routes: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
@@ -420,10 +514,13 @@ impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
 }
 
 impl Namespace {
-    fn new(cluster: &Arc<ClusterInfo>) -> Self {
+    fn new(name: String, cluster: &Arc<ClusterInfo>) -> Self {
+        let name = Arc::new(name);
         Self {
+            name: name.clone(),
             pods: AHashMap::default(),
             policies: PolicyIndex {
+                namespace: name,
                 cluster_info: cluster.clone(),
                 servers: AHashMap::default(),
                 http_routes: AHashMap::default(),
@@ -431,9 +528,15 @@ impl Namespace {
         }
     }
 
-    fn reindex_servers(&mut self, servers_by_addr: &mut ServersByAddr) {
-        for (_, pod) in &mut self.pods {
-            pod.reindex_servers(&mut self.policies, servers_by_addr)
+    fn reindex_servers(
+        &mut self,
+        servers_by_addr: &mut ServersByAddr,
+        client_policies: &ClientPolicyNsIndex,
+    ) {
+        let _span = tracing::info_span!("reindex", ns = %self.name).entered();
+        for (name, pod) in &mut self.pods {
+            let _span = tracing::info_span!("reindex_pod", pod = %name).entered();
+            pod.reindex_servers(servers_by_addr, client_policies, &mut self.policies)
         }
     }
 
@@ -441,6 +544,7 @@ impl Namespace {
         &mut self,
         name: String,
         pod: k8s::Pod,
+        client_policies: &ClientPolicyNsIndex,
         servers_by_addr: &mut ServersByAddr,
     ) -> Result<()> {
         let port_names = pod
@@ -515,7 +619,7 @@ impl Namespace {
         match pod {
             Some(pod) => {
                 tracing::info!("pod updated");
-                pod.reindex_servers(&mut self.policies, servers_by_addr);
+                pod.reindex_servers(servers_by_addr, client_policies, &mut self.policies)
             }
             None => {} // no update
         };
@@ -526,7 +630,12 @@ impl Namespace {
 
 impl Pod {
     /// Determines the policies for ports on this pod.
-    fn reindex_servers(&mut self, policies: &mut PolicyIndex, servers_by_addr: &mut ServersByAddr) {
+    fn reindex_servers(
+        &mut self,
+        servers_by_addr: &mut ServersByAddr,
+        client_policies: &ClientPolicyNsIndex,
+        ns_policies: &mut PolicyIndex,
+    ) {
         // Keep track of the ports that are already known in the pod so that, after applying server
         // matches, we can ensure remaining ports are set to the default policy.
         let mut unmatched_ports = self.port_servers.keys().copied().collect::<pod::PortSet>();
@@ -541,7 +650,7 @@ impl Pod {
             std::hash::BuildHasherDefault::<pod::PortHasher>::default(),
         );
 
-        for (srvname, server) in policies.servers.iter() {
+        for (srvname, server) in ns_policies.servers.iter() {
             if server.pod_selector.matches(&self.meta.labels) {
                 for port in self.select_ports(&server.port_ref).into_iter() {
                     // If the port is already matched to a server, then log a warning and skip
@@ -563,7 +672,12 @@ impl Pod {
                         .into_iter()
                         .flatten()
                         .map(|p| p.as_str());
-                    let s = policies.outbound_server(srvname.clone(), server, probe_paths);
+                    let s = ns_policies.outbound_server(
+                        srvname.clone(),
+                        server,
+                        client_policies,
+                        probe_paths,
+                    );
                     let rx = self.update_server(port, srvname, s);
                     match servers_by_addr.entry(addr) {
                         Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
@@ -581,7 +695,7 @@ impl Pod {
         // Reset all remaining ports to the default policy.
         for port in unmatched_ports.into_iter() {
             let addr = SocketAddr::new(self.ip, port.into());
-            let rx = self.set_default_server(port, &policies.cluster_info);
+            let rx = self.set_default_server(port, &ns_policies.cluster_info);
             match servers_by_addr.entry(addr) {
                 Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
                 Entry::Vacant(entry) => {
@@ -728,6 +842,7 @@ impl Pod {
             reference: core::ServerRef::Default(policy.as_str()),
             protocol,
             http_routes,
+            client_policy: None,
         }
     }
 }
@@ -736,6 +851,7 @@ impl PolicyIndex {
     fn update_server(&mut self, name: String, server: Server) -> bool {
         match self.servers.entry(name.clone()) {
             Entry::Vacant(entry) => {
+                tracing::debug!(server = %name, "no changes");
                 entry.insert(server);
             }
             Entry::Occupied(entry) => {
@@ -754,12 +870,16 @@ impl PolicyIndex {
     fn update_http_route(&mut self, name: String, route: OutboundRouteBinding) -> bool {
         match self.http_routes.entry(name) {
             Entry::Vacant(entry) => {
+                tracing::debug!(?route, "adding to index");
                 entry.insert(route);
             }
             Entry::Occupied(mut entry) => {
                 if *entry.get() == route {
+                    tracing::debug!(?route, "no changes");
                     return false;
                 }
+
+                tracing::debug!(?route, "updating");
                 entry.insert(route);
             }
         }
@@ -771,15 +891,18 @@ impl PolicyIndex {
         &self,
         name: String,
         server: &Server,
+        client_policies: &ClientPolicyNsIndex,
         probe_paths: impl Iterator<Item = &'p str>,
     ) -> OutboundServer {
         tracing::trace!(%name, ?server, "Creating outbound server");
-        let http_routes = self.http_routes(&name, probe_paths);
+        let mut http_routes = self.http_routes(&name, probe_paths);
+        let client_policy = self.client_policies(&name, client_policies, &mut http_routes);
 
         OutboundServer {
             reference: core::ServerRef::Server(name),
             protocol: server.protocol.clone(),
             http_routes,
+            client_policy,
         }
     }
 
@@ -803,9 +926,81 @@ impl PolicyIndex {
         }
         self.cluster_info.default_outbound_http_routes(probe_paths)
     }
+
+    fn client_policies(
+        &self,
+        server_name: &str,
+        client_policies: &ClientPolicyNsIndex,
+        http_routes: &mut HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
+    ) -> Option<client_policy::Spec> {
+        let mut server_policy = None;
+        let potential_policies = client_policies
+            .all_policies()
+            .filter(|(_, policy)| policy.target_ns() == *self.namespace);
+        for (name, policy) in potential_policies {
+            if policy.selects_server(self.namespace.as_ref(), server_name) {
+                tracing::debug!(policy = %name, server = %server_name, "policy selects server");
+                // TODO(eliza): how to handle multiple ClientPolicies selecting
+                // the same server?
+                assert_eq!(
+                    server_policy, None,
+                    "we already found a policy that selects this server!"
+                );
+                server_policy = Some(policy.clone());
+            }
+
+            for (reference, route) in http_routes.iter_mut() {
+                if policy.selects_route(self.namespace.as_ref(), reference) {
+                    tracing::debug!(
+                        policy = %name,
+                        route = ?reference,
+                        server = %server_name,
+                        "policy selects route on server",
+                    );
+
+                    // TODO(eliza): how to handle multiple ClientPolicies selecting
+                    // the same server?
+                    assert_eq!(
+                        server_policy, None,
+                        "we already found a policy that selects this route!"
+                    );
+                    route.client_policy = Some(policy.clone());
+                }
+            }
+        }
+        server_policy
+    }
 }
 
-// === imp NsUpdate ===
+// === impl ClientPolicyNsIndex ===
+
+impl ClientPolicyNsIndex {
+    /// Returns an iterator over all ClientPolicies in the index.
+    fn all_policies(&self) -> impl Iterator<Item = (&String, &client_policy::Spec)> + '_ {
+        self.by_ns.values().flat_map(|ns| ns.policies.iter())
+    }
+
+    fn update_policy(&mut self, ns: String, name: String, policy: client_policy::Spec) -> bool {
+        match self.by_ns.entry(ns).or_default().policies.entry(name) {
+            Entry::Vacant(entry) => {
+                tracing::debug!(?policy, "adding to index");
+                entry.insert(policy);
+            }
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == policy {
+                    tracing::debug!(?policy, "no changes");
+                    return false;
+                }
+                tracing::debug!(?policy, "updating");
+                entry.insert(policy);
+            }
+        }
+
+        true
+    }
+}
+
+// === impl NsUpdate ===
 
 impl<T> Default for NsUpdate<T> {
     fn default() -> Self {
@@ -861,6 +1056,7 @@ impl ClusterInfo {
                 filters: Vec::new(),
             }],
             creation_timestamp: None,
+            client_policy: None,
         };
         routes.insert(core::InboundHttpRouteRef::Default("probe"), probe_route);
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,8 +7,9 @@ use crate::{
     ClusterInfo,
 };
 use ahash::{AHashMap, AHashSet};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use client_policy_k8s_api::client_policy::ClientPolicy;
+use futures::TryFutureExt;
 use k8s::policy;
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
@@ -17,12 +18,14 @@ use std::{
         hash_map::{Entry, HashMap},
         BTreeSet,
     },
+    future::Future,
     net::{IpAddr, SocketAddr},
     num::NonZeroU16,
     sync::Arc,
 };
 use tokio::{
     sync::watch,
+    task,
     time::{Duration, Instant},
 };
 use tracing::Instrument;
@@ -115,31 +118,42 @@ impl Index {
         }
     }
 
-    pub fn index_pods(&self, rt: &mut kubert::Runtime) -> tokio::task::JoinHandle<()> {
+    pub fn spawn_index_tasks(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>> {
+        let pods = self.index_pods(rt);
+        let servers = self.index_resource::<k8s::policy::Server>(rt);
+        let routes = self.index_resource::<k8s::policy::HttpRoute>(rt);
+        let policies = self.index_resource::<ClientPolicy>(rt);
+        async move {
+            tokio::try_join! {
+                pods, servers, routes, policies,
+            }
+            .map(|_| ())
+        }
+    }
+
+    pub fn index_pods(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>> {
         let watch = rt.watch_all::<k8s::Pod>(ListParams::default().labels(CONTROL_PLANE_NS_LABEL));
         let index = kubert::index::namespaced(self.index.clone(), watch)
-            .instrument(tracing::info_span!("index_pods"));
+            .instrument(tracing::info_span!("index", kind = %"Pod"));
+
         let join = tokio::spawn(index);
-        tracing::info!("started pod indexing");
-        join
+        tracing::info!("started Pod indexing");
+        join.map_err(|err| anyhow!("index task for Pods failed: {err}"))
     }
 
-    pub fn index_servers(&self, rt: &mut kubert::Runtime) -> tokio::task::JoinHandle<()> {
-        let watch = rt.watch_all::<k8s::policy::Server>(ListParams::default());
+    fn index_resource<R>(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>>
+    where
+        R: kube::Resource + serde::de::DeserializeOwned + Clone + std::fmt::Debug + Send + 'static,
+        R::DynamicType: Default,
+        LockedIndex: kubert::index::IndexNamespacedResource<R>,
+    {
+        let kind = std::any::type_name::<R>().split("::").last().unwrap();
+        let watch = rt.watch_all::<R>(ListParams::default());
         let index = kubert::index::namespaced(self.index.clone(), watch)
-            .instrument(tracing::info_span!("index_servers"));
+            .instrument(tracing::info_span!("index", %kind));
         let join = tokio::spawn(index);
-        tracing::info!("started server indexing");
-        join
-    }
-
-    pub fn index_http_routes(&self, rt: &mut kubert::Runtime) -> tokio::task::JoinHandle<()> {
-        let watch = rt.watch_all::<k8s::policy::HttpRoute>(ListParams::default());
-        let index = kubert::index::namespaced(self.index.clone(), watch)
-            .instrument(tracing::info_span!("index_http_routes"));
-        let join = tokio::spawn(index);
-        tracing::info!("started HTTPRoute indexing");
-        join
+        tracing::info!("started {kind} indexing");
+        join.map_err(move |err| anyhow!("index task for {kind}s failed: {err}"))
     }
 
     pub fn dump_index(&self, every: Duration) -> tokio::task::JoinHandle<()> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -289,6 +289,15 @@ impl LockedIndex {
             self.changed = Instant::now();
         }
     }
+
+    fn reindex_all(&mut self) {
+        tracing::debug!("Reindexing all namespaces");
+        for ns in self.namespaces.values_mut() {
+            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
+        }
+
+        self.changed = Instant::now();
+    }
 }
 
 impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
@@ -330,17 +339,6 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
             self.changed = Instant::now();
         } else {
             tracing::debug!("tried to delete a pod in a namespace that does not exist!");
-        }
-    }
-}
-
-// === impl LockedIndex ===
-
-impl LockedIndex {
-    fn reindex_all(&mut self) {
-        tracing::debug!("Reindexing all namespaces");
-        for ns in self.namespaces.values_mut() {
-            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
         }
     }
 }
@@ -516,14 +514,55 @@ impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
         }
     }
 
-    fn reset(&mut self, routes: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
+    fn reset(&mut self, policies: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
         let _span = tracing::info_span!("reset").entered();
-        todo!("eliza")
+        let mut changed = false;
+        for policy in policies.into_iter() {
+            let ns = policy
+                .namespace()
+                .expect("ClientPolicy must have a namespace");
+            let name = policy.name_unchecked();
+            let spec = match client_policy::Spec::try_from(policy) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    tracing::warn!(%ns, %name, %error, "invalid ClientPolicy");
+                    continue;
+                }
+            };
+            changed |= self.client_policies.update_policy(ns, name, spec);
+        }
+        for (ns_name, names) in deleted.into_iter() {
+            let _span = tracing::debug_span!("delete", ns = %ns_name).entered();
+            if let Entry::Occupied(mut ns) = self.client_policies.by_ns.entry(ns_name) {
+                for name in names.into_iter() {
+                    ns.get_mut().policies.remove(&name);
+                    tracing::debug!(%name, "deleting ClientPolicy");
+                }
+                if ns.get().is_empty() {
+                    tracing::debug!("namespace has no ClientPolicies, removing it");
+                    ns.remove();
+                }
+            }
+        }
+
+        if changed {
+            self.reindex_all()
+        }
     }
 
     #[tracing::instrument(skip(self), fields(%ns, %name))]
     fn delete(&mut self, ns: String, name: String) {
-        todo!("eliza")
+        if let Entry::Occupied(mut ns) = self.client_policies.by_ns.entry(ns) {
+            tracing::debug!("deleting ClientPolicy");
+            ns.get_mut().policies.remove(&name);
+            if ns.get().is_empty() {
+                tracing::debug!("namespace has no client policies, deleting it");
+                ns.remove();
+            }
+            self.reindex_all();
+        } else {
+            tracing::warn!("namespace already deleted!");
+        }
     }
 }
 
@@ -1011,6 +1050,12 @@ impl ClientPolicyNsIndex {
         }
 
         true
+    }
+}
+
+impl ClientPolicyIndex {
+    fn is_empty(&self) -> bool {
+        self.policies.is_empty() // && self.bindings.is_empty()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,7 @@ async fn main() -> Result<()> {
         default_policy,
     });
 
-    index.index_pods(&mut rt);
-    index.index_servers(&mut rt);
-    index.index_http_routes(&mut rt);
+    let indices = index.spawn_index_tasks(&mut rt);
 
     if let Some(secs) = dump_interval_secs {
         index.dump_index(Duration::from_secs(secs));
@@ -122,6 +120,7 @@ async fn main() -> Result<()> {
 
     // Run the Kubert indexers.
     rt.run().await?;
+    indices.await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use client_policy_k8s_api::{
 use std::net::SocketAddr;
 use std::time::Duration;
 
+mod client_policy;
 mod defaults;
 pub mod index;
 mod pod;

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,24 +1,28 @@
-pub use crate::core::http_route::*;
-use crate::k8s::{
-    self,
-    policy::{httproute as policy, Server},
+pub(crate) use crate::core::http_route::*;
+use crate::{
+    client_policy,
+    k8s::{
+        self,
+        policy::{httproute as policy, Server},
+    },
 };
 use anyhow::{anyhow, Error, Result};
 use chrono::{offset::Utc, DateTime};
 use k8s_gateway_api as api;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundHttpRoute {
     pub hostnames: Vec<HostMatch>,
     // TODO(eliza): need a separate outbound rule type eventually...
     pub rules: Vec<InboundHttpRouteRule>,
+    pub client_policy: Option<client_policy::Spec>,
 
     /// This is required for ordering returned `HttpRoute`s by their creation
     /// timestamp.
     pub creation_timestamp: Option<DateTime<Utc>>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundRouteBinding {
     pub parents: Vec<OutboundParentRef>,
     pub route: OutboundHttpRoute,
@@ -30,6 +34,7 @@ impl Default for OutboundHttpRoute {
             hostnames: Vec::new(),
             rules: Vec::new(),
             creation_timestamp: None,
+            client_policy: None,
         }
     }
 }
@@ -83,6 +88,7 @@ impl TryFrom<policy::HttpRoute> for OutboundRouteBinding {
                 hostnames,
                 rules,
                 creation_timestamp,
+                client_policy: None,
             },
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client_policy::Spec,
     core::{self, ProxyProtocol},
     k8s,
     route::OutboundHttpRoute,
@@ -7,12 +8,13 @@ use crate::{
 use std::collections::HashMap;
 
 /// Like `linkerd_policy_controller_core::InboundServer`, but...outbound.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundServer {
     pub reference: core::ServerRef,
 
     pub protocol: ProxyProtocol,
     pub http_routes: HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
+    pub client_policy: Option<Spec>,
 }
 
 /// The parts of a `Server` resource that can change.


### PR DESCRIPTION
Depends on #3.

This branch updates the controller to index the ClientPolicy CRD and
bind ClientPolicies to OutboundServers, either at the Server level, or
to individual; HTTPRoutes on those Servers.

This depends on PR #3 because it relies on the HTTPRoute indexing added
in that branch.

[example](https://media.discordapp.net/attachments/814234309342527508/1018972765895794779/unknown.png?width=923&height=826)