### PR TITLE
index ClientPolicies and bind them to OutboundServers 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,7 @@ dependencies = [
  "client-policy-k8s-api",
  "comfy-table",
  "futures",
+ "humantime",
  "ipnet",
  "k8s-gateway-api",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "linkerd-policy-controller-core",
  "linkerd-policy-controller-k8s-api",
  "parking_lot",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "3", default-features = false, features = [
     "std",
 ] }
 futures = { version = "0.3", default-features = false }
+humantime = "2"
 ipnet = "2"
 k8s-openapi = { version = "0.15", features = ["v1_20"] }
 k8s-gateway-api = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,21 +13,22 @@ publish = false
 ahash = "0.7"
 anyhow = "1"
 chrono = "0.4"
+comfy-table = "6.1.0"
 clap = { version = "3", default-features = false, features = [
     "derive",
     "env",
     "std",
 ] }
+client-policy-k8s-api = { path = "./k8s/api" }
 futures = { version = "0.3", default-features = false }
 humantime = "2"
 ipnet = "2"
 k8s-openapi = { version = "0.15", features = ["v1_20"] }
 k8s-gateway-api = "0.6"
 parking_lot = "0.12"
+serde = "1"
 thiserror = "1"
 tracing = "0.1"
-comfy-table = "6.1.0"
-client-policy-k8s-api = { path = "./k8s/api" }
 
 [dependencies.kube]
 version = "0.74"

--- a/examples/clientpolicy.yml
+++ b/examples/clientpolicy.yml
@@ -4,9 +4,10 @@ metadata:
   name: authors-get
 spec:
   targetRef:
-    name: authors-get
+    name: authors-get-route
     kind: HTTPRoute
     group: policy.linkerd.io
+    namespace: booksapp
   failureClassification:
     statuses:
       - "401"

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -97,7 +97,7 @@ impl TryFrom<k8s::ClientPolicy> for Spec {
 impl Target {
     fn try_from_target_ref(ns: String, target: NamespacedTargetRef) -> Result<Self, Error> {
         match target {
-            t if t.targets_kind::<HttpRoute>() => Ok(Target::Server {
+            t if t.targets_kind::<policy::Server>() => Ok(Target::Server {
                 name: t.name,
                 namespace: t.namespace.unwrap_or(ns),
             }),

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -1,0 +1,92 @@
+use crate::k8s::policy::{self, HttpRoute, NamespacedTargetRef, Server};
+use anyhow::{Context, Error};
+use client_policy_k8s_api::client_policy as k8s;
+pub use k8s::FailureClassification;
+use std::{convert::TryFrom, time::Duration};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ClientPolicy {
+    pub target: Target,
+    pub failure_classification: FailureClassification,
+    pub filters: Vec<Filter>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Target {
+    /// This policy's parent ref is a `Server`.
+    Server {
+        name: String,
+        namespace: Option<String>,
+    },
+
+    /// This policy's parent ref is an `HTTPRoute`.
+    HttpRoute {
+        name: String,
+        namespace: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Filter {
+    Timeout(Duration),
+}
+
+// === impl ClientPolicy ===
+
+impl TryFrom<k8s::ClientPolicy> for ClientPolicy {
+    type Error = Error;
+
+    fn try_from(policy: k8s::ClientPolicy) -> Result<Self, Self::Error> {
+        let target = Target::try_from(policy.spec.target_ref)?;
+        // XXX(eliza): it would be good to validate that these are real http
+        // status ranges, but "meh".
+        let failure_classification = policy.spec.failure_classification;
+        let filters = policy
+            .spec
+            .filters
+            .into_iter()
+            .map(Filter::try_from)
+            .collect::<Result<_, _>>()?;
+        Ok(Self {
+            target,
+            failure_classification,
+            filters,
+        })
+    }
+}
+
+// === impl Target ===
+
+impl TryFrom<NamespacedTargetRef> for Target {
+    type Error = Error;
+
+    fn try_from(target_ref: NamespacedTargetRef) -> Result<Self, Self::Error> {
+        match target_ref {
+            t if t.targets_kind::<Server>() => Ok(Target::Server {
+                name: t.name,
+                namespace: t.namespace,
+            }),
+            t if t.targets_kind::<HttpRoute>() => Ok(Target::HttpRoute {
+                name: t.name,
+                namespace: t.namespace,
+            }),
+            _ => Err(anyhow::anyhow!(
+                "a ClientPolicy must target either a Server or an HTTPRoute"
+            )),
+        }
+    }
+}
+
+// === impl Filter ===
+
+impl TryFrom<k8s::ClientPolicyFilter> for Filter {
+    type Error = Error;
+
+    fn try_from(filter: k8s::ClientPolicyFilter) -> Result<Self, Self::Error> {
+        match filter {
+            k8s::ClientPolicyFilter::Timeout { timeout } => humantime::parse_duration(&timeout)
+                .map(Filter::Timeout)
+                .with_context(|| format!("invalid timeout duration '{timeout}'")),
+        }
+    }
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -1004,9 +1004,11 @@ impl PolicyIndex {
         let potential_policies = client_policies
             .all_policies()
             .filter(|(_, policy)| policy.target_ns() == *self.namespace);
+        let _span = tracing::debug_span!("client_policies", ns = %self.namespace.as_ref(), server = %server_name).entered();
         for (name, policy) in potential_policies {
+            let _span = tracing::debug_span!("policy", message = %name).entered();
             if policy.selects_server(self.namespace.as_ref(), server_name) {
-                tracing::debug!(policy = %name, server = %server_name, "policy selects server");
+                tracing::debug!("policy selects server");
                 // TODO(eliza): how to handle multiple ClientPolicies selecting
                 // the same server?
                 assert_eq!(
@@ -1014,16 +1016,14 @@ impl PolicyIndex {
                     "we already found a policy that selects this server!"
                 );
                 server_policy = Some(policy.clone());
+            } else {
+                tracing::debug!("policy does not select server");
             }
 
             for (reference, route) in http_routes.iter_mut() {
+                let _span = tracing::debug_span!("route", ?reference).entered();
                 if policy.selects_route(self.namespace.as_ref(), reference) {
-                    tracing::debug!(
-                        policy = %name,
-                        route = ?reference,
-                        server = %server_name,
-                        "policy selects route on server",
-                    );
+                    tracing::debug!("policy selects route on server");
 
                     // TODO(eliza): how to handle multiple ClientPolicies selecting
                     // the same server?
@@ -1032,6 +1032,8 @@ impl PolicyIndex {
                         "we already found a policy that selects this route!"
                     );
                     route.client_policy = Some(policy.clone());
+                } else {
+                    tracing::debug!("policy does not select this route");
                 }
             }
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core,
+    client_policy, core,
     k8s::{self, ResourceExt},
     pod,
     route::{OutboundHttpRoute, OutboundRouteBinding},
@@ -8,7 +8,8 @@ use crate::{
 };
 use ahash::{AHashMap, AHashSet};
 use anyhow::Result;
-use client_policy_k8s_api::client_policy::{self, ClientPolicy};
+use client_policy_k8s_api::client_policy::ClientPolicy;
+use k8s::policy;
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
 use std::{
@@ -35,14 +36,30 @@ pub struct Index {
 struct LockedIndex {
     cluster_info: Arc<ClusterInfo>,
     namespaces: AHashMap<String, Namespace>,
+    client_policies: ClientPolicyNsIndex,
     servers_by_addr: ServersByAddr,
     changed: Instant,
 }
 
 type ServersByAddr = HashMap<SocketAddr, watch::Receiver<OutboundServer>>;
 
+/// Holds all `ClientPolicy` and `ClientPolicyBinding` indices by-namespace.
+///
+/// This is separate from `NamespaceIndex` because client policies may reference
+/// target resources across namespaces.
+#[derive(Debug, Default)]
+struct ClientPolicyNsIndex {
+    by_ns: AHashMap<String, ClientPolicyIndex>,
+}
+
+#[derive(Debug, Default)]
+struct ClientPolicyIndex {
+    policies: AHashMap<String, client_policy::Spec>,
+}
+
 #[derive(Debug)]
 struct Namespace {
+    name: Arc<String>,
     pods: AHashMap<String, Pod>,
     policies: PolicyIndex,
 }
@@ -58,6 +75,7 @@ struct Pod {
 
 #[derive(Debug)]
 struct PolicyIndex {
+    namespace: Arc<String>,
     cluster_info: Arc<ClusterInfo>,
     servers: AHashMap<String, Server>,
     http_routes: AHashMap<String, OutboundRouteBinding>,
@@ -92,6 +110,7 @@ impl Index {
                 namespaces: AHashMap::new(),
                 servers_by_addr: HashMap::new(),
                 changed: Instant::now(),
+                client_policies: ClientPolicyNsIndex::default(),
             })),
         }
     }
@@ -140,6 +159,14 @@ impl Index {
     pub fn dump_index(&self, every: Duration) -> tokio::task::JoinHandle<()> {
         tracing::debug!(?every, "dumping index changes");
         let index = self.index.clone();
+
+        fn route_name(route: &core::InboundHttpRouteRef) -> &str {
+            match route {
+                core::InboundHttpRouteRef::Default(name) => name,
+                core::InboundHttpRouteRef::Linkerd(name) => name.as_str(),
+            }
+        }
+
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(every);
             let mut last_changed = index.read().changed;
@@ -153,7 +180,7 @@ impl Index {
                         .load_preset(UTF8_FULL)
                         .set_content_arrangement(ContentArrangement::Dynamic)
                         .set_header(Row::from(vec![
-                            "ADDRESS", "SERVER", "KIND", "PROTOCOL", "ROUTES",
+                            "ADDRESS", "SERVER", "KIND", "PROTOCOL", "ROUTES", "POLICIES",
                         ]));
                     for (addr, srv) in &index.servers_by_addr {
                         let srv = srv.borrow();
@@ -164,10 +191,18 @@ impl Index {
                         let route_list = srv
                             .http_routes
                             .keys()
-                            .map(|route| match route {
-                                core::InboundHttpRouteRef::Default(name) => name,
-                                core::InboundHttpRouteRef::Linkerd(name) => name.as_str(),
-                            })
+                            .map(route_name)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let policy_list = srv
+                            .client_policy
+                            .iter()
+                            .map(|policy| format!("server: {}", policy.name))
+                            .chain(srv.http_routes.iter().filter_map(|(route_ref, route)| {
+                                let policy = route.client_policy.as_ref()?;
+                                let route_name = route_name(route_ref);
+                                Some(format!("routes[{route_name}]: {}", policy.name))
+                            }))
                             .collect::<Vec<_>>()
                             .join("\n");
 
@@ -177,9 +212,39 @@ impl Index {
                             Cell::new(kind),
                             Cell::new(&format!("{:?}", srv.protocol)),
                             Cell::new(route_list),
+                            Cell::new(policy_list),
                         ]));
                     }
-                    println!("{srvs_by_addr}");
+
+                    let mut policies = Table::new();
+                    policies
+                        .load_preset(UTF8_FULL)
+                        .set_content_arrangement(ContentArrangement::Dynamic)
+                        .set_header(Row::from(vec![
+                            "NAMESPACE",
+                            "POLICY",
+                            "FAILURE CLASSIFICATION",
+                            "FILTERS",
+                        ]));
+                    let policies_by_ns =
+                        index
+                            .client_policies
+                            .by_ns
+                            .iter()
+                            .flat_map(|(ns_name, ns)| {
+                                ns.policies
+                                    .iter()
+                                    .map(move |(name, policy)| (ns_name, name, policy))
+                            });
+                    for (ns, name, policy) in policies_by_ns {
+                        policies.add_row(Row::from(vec![
+                            Cell::new(&ns),
+                            Cell::new(name),
+                            Cell::new(&format!("{:?}", policy.failure_classification)),
+                            Cell::new(format!("{:?}", policy.filters)),
+                        ]));
+                    }
+                    println!("{srvs_by_addr}\n{policies}");
                     last_changed = index.changed;
                 }
             }
@@ -194,7 +259,8 @@ impl LockedIndex {
                 if ns.get().pods.is_empty() {
                     ns.remove();
                 } else {
-                    ns.get_mut().reindex_servers(&mut self.servers_by_addr);
+                    ns.get_mut()
+                        .reindex_servers(&mut self.servers_by_addr, &self.client_policies);
                 }
 
                 self.changed = Instant::now();
@@ -215,10 +281,10 @@ impl LockedIndex {
     ) {
         let ns = self
             .namespaces
-            .entry(namespace)
-            .or_insert_with(|| Namespace::new(&self.cluster_info));
+            .entry(namespace.clone())
+            .or_insert_with(|| Namespace::new(namespace, &self.cluster_info));
         if f(ns) {
-            ns.reindex_servers(&mut self.servers_by_addr);
+            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
 
             self.changed = Instant::now();
         }
@@ -233,9 +299,11 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
 
         let ns = self
             .namespaces
-            .entry(ns)
-            .or_insert_with(|| Namespace::new(&self.cluster_info));
-        if let Err(error) = ns.update_pod(name, pod, &mut self.servers_by_addr) {
+            .entry(ns.clone())
+            .or_insert_with(|| Namespace::new(ns, &self.cluster_info));
+        if let Err(error) =
+            ns.update_pod(name, pod, &self.client_policies, &mut self.servers_by_addr)
+        {
             tracing::error!(%error, "illegal pod update");
         }
     }
@@ -262,6 +330,17 @@ impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
             self.changed = Instant::now();
         } else {
             tracing::debug!("tried to delete a pod in a namespace that does not exist!");
+        }
+    }
+}
+
+// === impl LockedIndex ===
+
+impl LockedIndex {
+    fn reindex_all(&mut self) {
+        tracing::debug!("Reindexing all namespaces");
+        for ns in self.namespaces.values_mut() {
+            ns.reindex_servers(&mut self.servers_by_addr, &self.client_policies);
         }
     }
 }
@@ -419,7 +498,22 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for LockedIn
 
 impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
     fn apply(&mut self, policy: ClientPolicy) {
-        todo!("eliza")
+        let ns = policy
+            .namespace()
+            .expect("ClientPolicy must have a namespace");
+        let name = policy.name_unchecked();
+        let _span = tracing::info_span!("apply", %ns, %name).entered();
+        let spec = match client_policy::Spec::try_from(policy) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tracing::warn!(%error, "invalid ClientPolicy");
+                return;
+            }
+        };
+
+        if self.client_policies.update_policy(ns, name, spec) {
+            self.reindex_all()
+        }
     }
 
     fn reset(&mut self, routes: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
@@ -434,10 +528,13 @@ impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
 }
 
 impl Namespace {
-    fn new(cluster: &Arc<ClusterInfo>) -> Self {
+    fn new(name: String, cluster: &Arc<ClusterInfo>) -> Self {
+        let name = Arc::new(name);
         Self {
+            name: name.clone(),
             pods: AHashMap::default(),
             policies: PolicyIndex {
+                namespace: name,
                 cluster_info: cluster.clone(),
                 servers: AHashMap::default(),
                 http_routes: AHashMap::default(),
@@ -445,9 +542,15 @@ impl Namespace {
         }
     }
 
-    fn reindex_servers(&mut self, servers_by_addr: &mut ServersByAddr) {
-        for (_, pod) in &mut self.pods {
-            pod.reindex_servers(&mut self.policies, servers_by_addr)
+    fn reindex_servers(
+        &mut self,
+        servers_by_addr: &mut ServersByAddr,
+        client_policies: &ClientPolicyNsIndex,
+    ) {
+        let _span = tracing::info_span!("reindex", ns = %self.name).entered();
+        for (name, pod) in &mut self.pods {
+            let _span = tracing::info_span!("reindex_pod", pod = %name).entered();
+            pod.reindex_servers(servers_by_addr, client_policies, &mut self.policies)
         }
     }
 
@@ -455,6 +558,7 @@ impl Namespace {
         &mut self,
         name: String,
         pod: k8s::Pod,
+        client_policies: &ClientPolicyNsIndex,
         servers_by_addr: &mut ServersByAddr,
     ) -> Result<()> {
         let port_names = pod
@@ -529,7 +633,7 @@ impl Namespace {
         match pod {
             Some(pod) => {
                 tracing::info!("pod updated");
-                pod.reindex_servers(&mut self.policies, servers_by_addr);
+                pod.reindex_servers(servers_by_addr, client_policies, &mut self.policies)
             }
             None => {} // no update
         };
@@ -540,7 +644,12 @@ impl Namespace {
 
 impl Pod {
     /// Determines the policies for ports on this pod.
-    fn reindex_servers(&mut self, policies: &mut PolicyIndex, servers_by_addr: &mut ServersByAddr) {
+    fn reindex_servers(
+        &mut self,
+        servers_by_addr: &mut ServersByAddr,
+        client_policies: &ClientPolicyNsIndex,
+        ns_policies: &mut PolicyIndex,
+    ) {
         // Keep track of the ports that are already known in the pod so that, after applying server
         // matches, we can ensure remaining ports are set to the default policy.
         let mut unmatched_ports = self.port_servers.keys().copied().collect::<pod::PortSet>();
@@ -555,7 +664,7 @@ impl Pod {
             std::hash::BuildHasherDefault::<pod::PortHasher>::default(),
         );
 
-        for (srvname, server) in policies.servers.iter() {
+        for (srvname, server) in ns_policies.servers.iter() {
             if server.pod_selector.matches(&self.meta.labels) {
                 for port in self.select_ports(&server.port_ref).into_iter() {
                     // If the port is already matched to a server, then log a warning and skip
@@ -577,7 +686,12 @@ impl Pod {
                         .into_iter()
                         .flatten()
                         .map(|p| p.as_str());
-                    let s = policies.outbound_server(srvname.clone(), server, probe_paths);
+                    let s = ns_policies.outbound_server(
+                        srvname.clone(),
+                        server,
+                        client_policies,
+                        probe_paths,
+                    );
                     let rx = self.update_server(port, srvname, s);
                     match servers_by_addr.entry(addr) {
                         Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
@@ -595,7 +709,7 @@ impl Pod {
         // Reset all remaining ports to the default policy.
         for port in unmatched_ports.into_iter() {
             let addr = SocketAddr::new(self.ip, port.into());
-            let rx = self.set_default_server(port, &policies.cluster_info);
+            let rx = self.set_default_server(port, &ns_policies.cluster_info);
             match servers_by_addr.entry(addr) {
                 Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
                 Entry::Vacant(entry) => {
@@ -742,6 +856,7 @@ impl Pod {
             reference: core::ServerRef::Default(policy.as_str()),
             protocol,
             http_routes,
+            client_policy: None,
         }
     }
 }
@@ -750,6 +865,7 @@ impl PolicyIndex {
     fn update_server(&mut self, name: String, server: Server) -> bool {
         match self.servers.entry(name.clone()) {
             Entry::Vacant(entry) => {
+                tracing::debug!(server = %name, "no changes");
                 entry.insert(server);
             }
             Entry::Occupied(entry) => {
@@ -768,12 +884,16 @@ impl PolicyIndex {
     fn update_http_route(&mut self, name: String, route: OutboundRouteBinding) -> bool {
         match self.http_routes.entry(name) {
             Entry::Vacant(entry) => {
+                tracing::debug!(?route, "adding to index");
                 entry.insert(route);
             }
             Entry::Occupied(mut entry) => {
                 if *entry.get() == route {
+                    tracing::debug!(?route, "no changes");
                     return false;
                 }
+
+                tracing::debug!(?route, "updating");
                 entry.insert(route);
             }
         }
@@ -785,15 +905,18 @@ impl PolicyIndex {
         &self,
         name: String,
         server: &Server,
+        client_policies: &ClientPolicyNsIndex,
         probe_paths: impl Iterator<Item = &'p str>,
     ) -> OutboundServer {
         tracing::trace!(%name, ?server, "Creating outbound server");
-        let http_routes = self.http_routes(&name, probe_paths);
+        let mut http_routes = self.http_routes(&name, probe_paths);
+        let client_policy = self.client_policies(&name, client_policies, &mut http_routes);
 
         OutboundServer {
             reference: core::ServerRef::Server(name),
             protocol: server.protocol.clone(),
             http_routes,
+            client_policy,
         }
     }
 
@@ -817,9 +940,81 @@ impl PolicyIndex {
         }
         self.cluster_info.default_outbound_http_routes(probe_paths)
     }
+
+    fn client_policies(
+        &self,
+        server_name: &str,
+        client_policies: &ClientPolicyNsIndex,
+        http_routes: &mut HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
+    ) -> Option<client_policy::Spec> {
+        let mut server_policy = None;
+        let potential_policies = client_policies
+            .all_policies()
+            .filter(|(_, policy)| policy.target_ns() == *self.namespace);
+        for (name, policy) in potential_policies {
+            if policy.selects_server(self.namespace.as_ref(), server_name) {
+                tracing::debug!(policy = %name, server = %server_name, "policy selects server");
+                // TODO(eliza): how to handle multiple ClientPolicies selecting
+                // the same server?
+                assert_eq!(
+                    server_policy, None,
+                    "we already found a policy that selects this server!"
+                );
+                server_policy = Some(policy.clone());
+            }
+
+            for (reference, route) in http_routes.iter_mut() {
+                if policy.selects_route(self.namespace.as_ref(), reference) {
+                    tracing::debug!(
+                        policy = %name,
+                        route = ?reference,
+                        server = %server_name,
+                        "policy selects route on server",
+                    );
+
+                    // TODO(eliza): how to handle multiple ClientPolicies selecting
+                    // the same server?
+                    assert_eq!(
+                        server_policy, None,
+                        "we already found a policy that selects this route!"
+                    );
+                    route.client_policy = Some(policy.clone());
+                }
+            }
+        }
+        server_policy
+    }
 }
 
-// === imp NsUpdate ===
+// === impl ClientPolicyNsIndex ===
+
+impl ClientPolicyNsIndex {
+    /// Returns an iterator over all ClientPolicies in the index.
+    fn all_policies(&self) -> impl Iterator<Item = (&String, &client_policy::Spec)> + '_ {
+        self.by_ns.values().flat_map(|ns| ns.policies.iter())
+    }
+
+    fn update_policy(&mut self, ns: String, name: String, policy: client_policy::Spec) -> bool {
+        match self.by_ns.entry(ns).or_default().policies.entry(name) {
+            Entry::Vacant(entry) => {
+                tracing::debug!(?policy, "adding to index");
+                entry.insert(policy);
+            }
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == policy {
+                    tracing::debug!(?policy, "no changes");
+                    return false;
+                }
+                tracing::debug!(?policy, "updating");
+                entry.insert(policy);
+            }
+        }
+
+        true
+    }
+}
+
+// === impl NsUpdate ===
 
 impl<T> Default for NsUpdate<T> {
     fn default() -> Self {
@@ -875,6 +1070,7 @@ impl ClusterInfo {
                 filters: Vec::new(),
             }],
             creation_timestamp: None,
+            client_policy: None,
         };
         routes.insert(core::InboundHttpRouteRef::Default("probe"), probe_route);
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use ahash::{AHashMap, AHashSet};
 use anyhow::Result;
+use client_policy_k8s_api::client_policy::{self, ClientPolicy};
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
 use std::{
@@ -413,6 +414,22 @@ impl kubert::index::IndexNamespacedResource<k8s::policy::HttpRoute> for LockedIn
     fn delete(&mut self, ns: String, name: String) {
         let _span = tracing::info_span!("delete", %ns, %name).entered();
         self.ns_with_reindex(ns, |ns| ns.policies.http_routes.remove(&name).is_some())
+    }
+}
+
+impl kubert::index::IndexNamespacedResource<ClientPolicy> for LockedIndex {
+    fn apply(&mut self, policy: ClientPolicy) {
+        todo!("eliza")
+    }
+
+    fn reset(&mut self, routes: Vec<ClientPolicy>, deleted: kubert::index::NamespacedRemoved) {
+        let _span = tracing::info_span!("reset").entered();
+        todo!("eliza")
+    }
+
+    #[tracing::instrument(skip(self), fields(%ns, %name))]
+    fn delete(&mut self, ns: String, name: String) {
+        todo!("eliza")
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,7 @@ async fn main() -> Result<()> {
         default_policy,
     });
 
-    index.index_pods(&mut rt);
-    index.index_servers(&mut rt);
-    index.index_http_routes(&mut rt);
+    let indices = index.spawn_index_tasks(&mut rt);
 
     if let Some(secs) = dump_interval_secs {
         index.dump_index(Duration::from_secs(secs));
@@ -122,6 +120,7 @@ async fn main() -> Result<()> {
 
     // Run the Kubert indexers.
     rt.run().await?;
+    indices.await?;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use client_policy_k8s_api::{
 use std::net::SocketAddr;
 use std::time::Duration;
 
+mod client_policy;
 mod defaults;
 pub mod index;
 mod pod;

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,24 +1,28 @@
-pub use crate::core::http_route::*;
-use crate::k8s::{
-    self,
-    policy::{httproute as policy, Server},
+pub(crate) use crate::core::http_route::*;
+use crate::{
+    client_policy,
+    k8s::{
+        self,
+        policy::{httproute as policy, Server},
+    },
 };
 use anyhow::{anyhow, Error, Result};
 use chrono::{offset::Utc, DateTime};
 use k8s_gateway_api as api;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundHttpRoute {
     pub hostnames: Vec<HostMatch>,
     // TODO(eliza): need a separate outbound rule type eventually...
     pub rules: Vec<InboundHttpRouteRule>,
+    pub client_policy: Option<client_policy::Spec>,
 
     /// This is required for ordering returned `HttpRoute`s by their creation
     /// timestamp.
     pub creation_timestamp: Option<DateTime<Utc>>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundRouteBinding {
     pub parents: Vec<OutboundParentRef>,
     pub route: OutboundHttpRoute,
@@ -30,6 +34,7 @@ impl Default for OutboundHttpRoute {
             hostnames: Vec::new(),
             rules: Vec::new(),
             creation_timestamp: None,
+            client_policy: None,
         }
     }
 }
@@ -83,6 +88,7 @@ impl TryFrom<policy::HttpRoute> for OutboundRouteBinding {
                 hostnames,
                 rules,
                 creation_timestamp,
+                client_policy: None,
             },
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,5 @@
 use crate::{
+    client_policy::Spec,
     core::{self, ProxyProtocol},
     k8s,
     route::OutboundHttpRoute,
@@ -7,12 +8,13 @@ use crate::{
 use std::collections::HashMap;
 
 /// Like `linkerd_policy_controller_core::InboundServer`, but...outbound.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct OutboundServer {
     pub reference: core::ServerRef,
 
     pub protocol: ProxyProtocol,
     pub http_routes: HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
+    pub client_policy: Option<Spec>,
 }
 
 /// The parts of a `Server` resource that can change.


### PR DESCRIPTION
Opening a new PR for this because I accidentally merged PR #5 into PR #3
after it merged, rather than into `main`. My bad!

Depends on #3.

This branch updates the controller to index the ClientPolicy CRD and
bind ClientPolicies to OutboundServers, either at the Server level, or
to individual; HTTPRoutes on those Servers.

This depends on PR #3 because it relies on the HTTPRoute indexing added
in that branch.

![image](https://user-images.githubusercontent.com/2796466/189952596-bc8f9e0d-fce7-45e9-9192-d9869ad8738b.png)
