### PR TITLE
rename resource type to HTTPClientPolicy

### DIFF
--- a/client-policy-controller.yml
+++ b/client-policy-controller.yml
@@ -96,9 +96,9 @@ rules:
       - policy.linkerd.io
     resources:
       - authorizationpolicies
-      - clientpolicies
       - clientpolicybindings
       - httproutes
+      - httpclientpolicies
       - servers
     verbs:
       - get

--- a/crds/httpclientpolicy.yml
+++ b/crds/httpclientpolicy.yml
@@ -2,14 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: clientpolicies.policy.linkerd.io
+  name: httpclientpolicies.policy.linkerd.io
 spec:
   group: policy.linkerd.io
   names:
-    kind: ClientPolicy
-    listKind: ClientPolicyList
-    plural: clientpolicies
-    singular: clientpolicy
+    kind: HTTPClientPolicy
+    listKind: HTTPClientPolicyList
+    plural: httpclientpolicies
+    singular: httpclientpolicy
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/examples/clientpolicy.yml
+++ b/examples/clientpolicy.yml
@@ -1,5 +1,5 @@
 apiVersion: policy.linkerd.io/v1alpha1
-kind: ClientPolicy
+kind: HTTPClientPolicy
 metadata:
   name: authors-get
 spec:

--- a/examples/clientpolicybinding.yml
+++ b/examples/clientpolicybinding.yml
@@ -5,19 +5,19 @@ metadata:
 spec:
   policyRefs:
     - group: policy.linkerd.io
-      kind: ClientPolicy
+      kind: HTTPClientPolicy
       namespace: booksapp
       name: authors-get
     - group: policy.linkerd.io
-      kind: ClientPolicy
+      kind: HTTPClientPolicy
       namespace: booksapp
       name: authors-delete
     - group: policy.linkerd.io
-      kind: ClientPolicy
+      kind: HTTPClientPolicy
       namespace: booksapp
       name: books-get
     - group: policy.linkerd.io
-      kind: ClientPolicy
+      kind: HTTPClientPolicy
       namespace: booksapp
       name: books-delete
   podSelector:

--- a/k8s/api/src/client_policy.rs
+++ b/k8s/api/src/client_policy.rs
@@ -6,25 +6,25 @@ use linkerd_policy_controller_k8s_api::policy::NamespacedTargetRef;
 #[kube(
     group = "policy.linkerd.io",
     version = "v1alpha1",
-    kind = "ClientPolicy",
+    kind = "HttpClientPolicy",
     namespaced
 )]
 #[serde(rename_all = "camelCase")]
-pub struct ClientPolicySpec {
+pub struct HttpClientPolicySpec {
     pub target_ref: NamespacedTargetRef,
-    pub failure_classification: FailureClassification,
-    pub filters: Vec<ClientPolicyFilter>,
+    pub failure_classification: HttpFailureClassification,
+    pub filters: Vec<HttpClientPolicyFilter>,
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct FailureClassification {
+pub struct HttpFailureClassification {
     pub statuses: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 #[serde(tag = "type", rename_all = "PascalCase")]
-pub enum ClientPolicyFilter {
+pub enum HttpClientPolicyFilter {
     // TODO: Add more filter varients
     Timeout { timeout: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use crate::index::Index;
 use anyhow::Result;
 use clap::Parser;
 use client_policy_k8s_api::{
-    client_policy::ClientPolicy, client_policy_binding::ClientPolicyBinding,
+    client_policy::HttpClientPolicy, client_policy_binding::ClientPolicyBinding,
 };
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -96,11 +96,11 @@ async fn main() -> Result<()> {
 
     let client = rt.client();
 
-    let client_policies = kube::Api::<ClientPolicy>::all(client.clone())
+    let client_policies = kube::Api::<HttpClientPolicy>::all(client.clone())
         .list(&kube::api::ListParams::default())
         .await?;
     for client_policy in client_policies.items.into_iter() {
-        tracing::info!(?client_policy, "Look at this cool policy!");
+        tracing::info!(?client_policy, "Look at this cool HTTP policy!");
     }
 
     let client_policy_bindings = kube::Api::<ClientPolicyBinding>::all(client)


### PR DESCRIPTION
This way, we can create separate resources for TCPClientPolicy, GRPCClientPolicy, etc... later.