### PR TITLE
implement ClientPolicyBinding

### DIFF
--- a/client-policy-controller.yml
+++ b/client-policy-controller.yml
@@ -73,7 +73,7 @@ spec:
           args:
             - --admin-addr=0.0.0.0:9991
             - --grpc-addr=0.0.0.0:8091
-            - --dump-interval-secs=5
+            - --dump-index
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/examples/books-binding.yml
+++ b/examples/books-binding.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: policy.linkerd.io/v1alpha1
+kind: ClientPolicyBinding
+metadata:
+  name: books
+spec:
+  policyRefs:
+    - group: policy.linkerd.io
+      kind: HTTPClientPolicy
+      namespace: booksapp
+      name: books
+  podSelector:
+    matchExpressions:
+      - { key: app, operator: NotIn, values: [] }
+

--- a/examples/books-clientpolicy.yml
+++ b/examples/books-clientpolicy.yml
@@ -1,5 +1,5 @@
 apiVersion: policy.linkerd.io/v1alpha1
-kind: ClientPolicy
+kind: HTTPClientPolicy
 metadata:
   name: books
 spec:

--- a/examples/clientpolicybinding.yml
+++ b/examples/clientpolicybinding.yml
@@ -2,6 +2,7 @@ apiVersion: policy.linkerd.io/v1alpha1
 kind: ClientPolicyBinding
 metadata:
   name: authors
+  namespace: booksapp
 spec:
   policyRefs:
     - group: policy.linkerd.io

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -1,11 +1,11 @@
 use crate::{
-    core,
+    core, index,
     k8s::{
         self,
         policy::{HttpRoute, NamespacedTargetRef},
     },
 };
-use ahash::AHashMap;
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use anyhow::{anyhow, ensure, Context, Error};
 pub use client_policy::HttpFailureClassification;
 use client_policy_k8s_api::{
@@ -14,7 +14,7 @@ use client_policy_k8s_api::{
 };
 use k8s_openapi::api;
 use kube::ResourceExt;
-use std::{convert::TryFrom, time::Duration};
+use std::{collections::hash_map::Entry, convert::TryFrom, fmt, time::Duration};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Spec {
@@ -38,6 +38,13 @@ pub struct Bound {
     pub client_pod_selector: k8s::labels::Selector,
 }
 
+/// The set of client policies and bindings on a `Service` or `HttpRoute`.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct PolicySet {
+    pub policies: HashMap<PolicyRef, Spec>,
+    pub bindings: HashMap<PolicyRef, Bound>,
+}
+
 #[derive(Hash, Clone, Debug, PartialEq, Eq)]
 pub struct PolicyRef {
     pub name: String,
@@ -53,6 +60,15 @@ pub enum Target {
     HttpRoute { name: String, namespace: String },
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TargetRef<'a> {
+    /// This policy's parent ref is a `Service`.
+    Service { name: &'a str, namespace: &'a str },
+
+    /// This policy's parent ref is an `HTTPRoute`.
+    HttpRoute { name: &'a str, namespace: &'a str },
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Filter {
     Timeout(Duration),
@@ -65,6 +81,32 @@ impl Spec {
         match self.target {
             Target::Service { ref namespace, .. } => namespace,
             Target::HttpRoute { ref namespace, .. } => namespace,
+        }
+    }
+
+    pub fn selects(&self, target_ref: TargetRef<'_>) -> bool {
+        match (target_ref, &self.target) {
+            (
+                TargetRef::Service {
+                    name: n,
+                    namespace: ns,
+                },
+                Target::Service {
+                    ref name,
+                    ref namespace,
+                },
+            ) => name == n && namespace == ns,
+            (
+                TargetRef::HttpRoute {
+                    name: n,
+                    namespace: ns,
+                },
+                Target::HttpRoute {
+                    ref name,
+                    ref namespace,
+                },
+            ) => name == n && namespace == ns,
+            _ => false,
         }
     }
 
@@ -176,6 +218,79 @@ impl TryFrom<client_policy::HttpClientPolicyFilter> for Filter {
                     .map(Filter::Timeout)
                     .with_context(|| format!("invalid timeout duration '{timeout}'"))
             }
+        }
+    }
+}
+
+// === impl PolicySet ===
+
+impl PolicySet {
+    pub fn reindex(&mut self, target: TargetRef<'_>, index: &index::ClientPolicyNsIndex) -> bool {
+        let mut changed = false;
+        let mut unmatched_policies = self.policies.keys().cloned().collect::<HashSet<_>>();
+        for (policy, spec) in index.policies_for(target) {
+            let _span = tracing::debug_span!("policy", policy.ns = %policy.namespace, message = %policy.name).entered();
+            unmatched_policies.remove(&policy);
+            match self.policies.entry(policy) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get() != spec {
+                        tracing::debug!("updated policy");
+                        entry.insert(spec.clone());
+                        changed = true;
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    tracing::debug!("added policy");
+                    entry.insert(spec.clone());
+                    changed = true;
+                }
+            }
+        }
+        for policy in unmatched_policies {
+            tracing::debug!(policy.ns = %policy.namespace, %policy.name, "removed policy");
+            self.policies.remove(&policy);
+            changed = true;
+        }
+
+        let mut unmatched_bindings = self.bindings.keys().cloned().collect::<HashSet<_>>();
+        for (binding, spec) in index.bindings_for(&self.policies) {
+            let _span = tracing::debug_span!("binding", binding.ns = %binding.namespace, message = %binding.name).entered();
+            unmatched_bindings.remove(&binding);
+            match self.bindings.entry(binding) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get() != &spec {
+                        tracing::debug!("updated policy binding");
+                        entry.insert(spec);
+                        changed = true;
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    tracing::debug!("added policy binding");
+                    entry.insert(spec);
+                    changed = true;
+                }
+            }
+        }
+
+        for binding in unmatched_bindings {
+            tracing::debug!(binding.ns = %binding.namespace, %binding.name, "removed policy binding");
+            self.bindings.remove(&binding);
+            changed = true;
+        }
+
+        if !changed {
+            tracing::debug!("no changes");
+        }
+
+        changed
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Target::Service { name, namespace } => write!(f, "Service {}/{}", namespace, name),
+            Target::HttpRoute { name, namespace } => write!(f, "HTTPRoute {}/{}", namespace, name),
         }
     }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -6,18 +6,17 @@ use crate::{
     service::{self, OutboundService, OutboundServiceRef},
     ClusterInfo,
 };
-use ahash::{AHashMap, AHashSet};
+use ahash::{AHashMap as HashMap, AHashSet};
 use anyhow::{anyhow, Result};
-use client_policy_k8s_api::client_policy::HttpClientPolicy;
+use client_policy_k8s_api::{
+    client_policy::HttpClientPolicy, client_policy_binding::ClientPolicyBinding,
+};
 use futures::TryFutureExt;
 use k8s_openapi::api::core::v1::Service;
 use kubert::client::api::ListParams;
 use parking_lot::RwLock;
 use std::{
-    collections::{
-        hash_map::{Entry, HashMap},
-        BTreeSet,
-    },
+    collections::{hash_map::Entry, BTreeSet},
     future::Future,
     net::{IpAddr, SocketAddr},
     num::NonZeroU16,
@@ -37,32 +36,33 @@ pub struct Index {
 #[derive(Debug)]
 struct LockedIndex {
     cluster_info: Arc<ClusterInfo>,
-    namespaces: AHashMap<String, Namespace>,
+    namespaces: HashMap<String, Namespace>,
     client_policies: ClientPolicyNsIndex,
-    servers_by_addr: ServersByAddr,
+    services_by_addr: ServicesByAddr,
     changed: Instant,
 }
 
-type ServersByAddr = HashMap<SocketAddr, watch::Receiver<OutboundService>>;
+type ServicesByAddr = HashMap<SocketAddr, watch::Receiver<OutboundService>>;
 
-/// Holds all `ClientPolicy` and `ClientPolicyBinding` indices by-namespace.
+/// Holds all `ClientPolicy` indices by-namespace.
 ///
 /// This is separate from `NamespaceIndex` because client policies may reference
 /// target resources across namespaces.
 #[derive(Debug, Default)]
-struct ClientPolicyNsIndex {
-    by_ns: AHashMap<String, ClientPolicyIndex>,
+pub struct ClientPolicyNsIndex {
+    by_ns: HashMap<String, ClientPolicyIndex>,
 }
 
 #[derive(Debug, Default)]
 struct ClientPolicyIndex {
-    policies: AHashMap<String, client_policy::Spec>,
+    policies: HashMap<String, client_policy::Spec>,
+    bindings: HashMap<String, client_policy::Binding>,
 }
 
 #[derive(Debug)]
 struct Namespace {
     name: Arc<String>,
-    pods: AHashMap<String, Pod>,
+    pods: HashMap<String, Pod>,
     policies: PolicyIndex,
 }
 
@@ -70,8 +70,8 @@ struct Namespace {
 struct Pod {
     meta: pod::Meta,
     ip: IpAddr,
-    port_names: AHashMap<String, pod::PortSet>,
-    port_servers: pod::PortMap<PodPortServer>,
+    port_names: HashMap<String, pod::PortSet>,
+    // port_servers: pod::PortMap<PodPortServer>,
     probes: pod::PortMap<BTreeSet<String>>,
 }
 
@@ -79,28 +79,13 @@ struct Pod {
 struct PolicyIndex {
     namespace: Arc<String>,
     cluster_info: Arc<ClusterInfo>,
-    services: AHashMap<String, service::Spec>,
-    http_routes: AHashMap<String, OutboundRouteBinding>,
+    services: HashMap<String, watch::Sender<OutboundService>>,
+    http_routes: HashMap<String, OutboundRouteBinding>,
 }
 
 struct NsUpdate<T> {
     added: Vec<(String, T)>,
     removed: AHashSet<String>,
-}
-
-/// Holds the state of a single port on a pod.
-#[derive(Debug)]
-struct PodPortServer {
-    /// The name of the server resource that matches this port. Unset when no
-    /// server resources match this pod/port (and, i.e., the default policy is
-    /// used).
-    name: Option<String>,
-
-    /// A sender used to broadcast pod port server updates.
-    tx: watch::Sender<OutboundService>,
-
-    /// A receiver that is updated when the pod's server is updated.
-    rx: watch::Receiver<OutboundService>,
 }
 const CONTROL_PLANE_NS_LABEL: &str = "linkerd.io/control-plane-ns";
 
@@ -109,8 +94,8 @@ impl Index {
         Self {
             index: Arc::new(RwLock::new(LockedIndex {
                 cluster_info: Arc::new(cluster),
-                namespaces: AHashMap::new(),
-                servers_by_addr: HashMap::new(),
+                namespaces: HashMap::new(),
+                services_by_addr: HashMap::new(),
                 changed: Instant::now(),
                 client_policies: ClientPolicyNsIndex::default(),
             })),
@@ -125,34 +110,36 @@ impl Index {
     pub fn addr_server_rx(&self, addr: SocketAddr) -> Result<watch::Receiver<OutboundService>> {
         self.index
             .read()
-            .servers_by_addr
+            .services_by_addr
             .get(&addr)
             .cloned()
             .ok_or_else(|| anyhow::anyhow!("no server found for address {}", addr))
     }
 
     pub fn spawn_index_tasks(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>> {
-        let pods = self.index_pods(rt);
+        // let pods = self.index_pods(rt);
         let services = self.index_resource::<Service>(rt);
         let routes = self.index_resource::<k8s::policy::HttpRoute>(rt);
         let policies = self.index_resource::<HttpClientPolicy>(rt);
+        let bindings = self.index_resource::<ClientPolicyBinding>(rt);
         async move {
             tokio::try_join! {
-                pods, services, routes, policies,
+                // pods,
+                services, routes, policies, bindings,
             }
             .map(|_| ())
         }
     }
 
-    fn index_pods(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>> {
-        let watch = rt.watch_all::<k8s::Pod>(ListParams::default().labels(CONTROL_PLANE_NS_LABEL));
-        let index = kubert::index::namespaced(self.index.clone(), watch)
-            .instrument(tracing::info_span!("index", kind = %"Pod"));
+    // fn index_pods(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>> {
+    //     let watch = rt.watch_all::<k8s::Pod>(ListParams::default().labels(CONTROL_PLANE_NS_LABEL));
+    //     let index = kubert::index::namespaced(self.index.clone(), watch)
+    //         .instrument(tracing::info_span!("index", kind = %"Pod"));
 
-        let join = tokio::spawn(index);
-        tracing::info!("started Pod indexing");
-        join.map_err(|err| anyhow!("index task for Pods failed: {err}"))
-    }
+    //     let join = tokio::spawn(index);
+    //     tracing::info!("started Pod indexing");
+    //     join.map_err(|err| anyhow!("index task for Pods failed: {err}"))
+    // }
 
     fn index_resource<R>(&self, rt: &mut kubert::Runtime) -> impl Future<Output = Result<()>>
     where
@@ -193,35 +180,38 @@ impl Index {
                         .load_preset(UTF8_FULL)
                         .set_content_arrangement(ContentArrangement::Dynamic)
                         .set_header(Row::from(vec![
-                            "ADDRESS", "FQDN", "SERVICE", "PROTOCOL", "ROUTES", "POLICIES",
+                            "ADDRESS",
+                            "SERVICE",
+                            "FQDN",
+                            "POLICY BINDINGS",
                         ]));
-                    for (addr, svc) in &index.servers_by_addr {
+                    for (addr, svc) in &index.services_by_addr {
                         let svc = svc.borrow();
-                        let route_list = svc
-                            .http_routes
-                            .keys()
-                            .map(route_name)
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        let policy_list = svc
-                            .client_policy
+                        // let route_list = svc
+                        //     .http_routes
+                        //     .keys()
+                        //     .map(route_name)
+                        //     .collect::<Vec<_>>()
+                        //     .join("\n");
+                        let bindings = svc
+                            .client_bindings
                             .iter()
-                            .map(|policy| format!("service: {}", policy.name))
-                            .chain(svc.http_routes.iter().filter_map(|(route_ref, route)| {
-                                let policy = route.client_policy.as_ref()?;
-                                let route_name = route_name(route_ref);
-                                Some(format!("routes[{route_name}]: {}", policy.name))
-                            }))
+                            .map(|(&client_policy::PolicyRef { ref name, .. }, bound)| {
+                                use std::fmt::Write;
+                                let mut policies = String::new();
+                                for policy in bound.policies.iter() {
+                                    write!(&mut policies, "\n - {policy:?}");
+                                }
+                                format!("{name}: {:?}\n{policies}", bound.client_pod_selector)
+                            })
                             .collect::<Vec<_>>()
                             .join("\n");
 
                         svcs_by_addr.add_row(Row::from(vec![
                             Cell::new(&addr.to_string()),
+                            Cell::new(svc.reference.to_string()),
                             Cell::new(format!("{:?}", svc.fqdn)),
-                            Cell::new(svc.reference.as_str()),
-                            Cell::new(&format!("{:?}", svc.protocol)),
-                            Cell::new(route_list),
-                            Cell::new(policy_list),
+                            Cell::new(bindings),
                         ]));
                     }
 
@@ -268,8 +258,7 @@ impl LockedIndex {
                 if ns.get().pods.is_empty() {
                     ns.remove();
                 } else {
-                    ns.get_mut()
-                        .reindex_services(&mut self.servers_by_addr, &self.client_policies);
+                    ns.get_mut().reindex_policies(&self.client_policies);
                 }
 
                 self.changed = Instant::now();
@@ -277,11 +266,11 @@ impl LockedIndex {
         }
     }
 
-    // fn ns_or_default(&mut self, namespace: String) -> &mut Namespace {
-    //     self.namespaces
-    //         .entry(namespace)
-    //         .or_insert_with(|| Namespace::new(&self.cluster_info))
-    // }
+    fn ns_or_default(&mut self, namespace: String) -> &mut Namespace {
+        self.namespaces
+            .entry(namespace.clone())
+            .or_insert_with(|| Namespace::new(namespace, &self.cluster_info))
+    }
 
     fn ns_or_default_with_reindex(
         &mut self,
@@ -293,7 +282,7 @@ impl LockedIndex {
             .entry(namespace.clone())
             .or_insert_with(|| Namespace::new(namespace, &self.cluster_info));
         if f(ns) {
-            ns.reindex_services(&mut self.servers_by_addr, &self.client_policies);
+            ns.reindex_policies(&self.client_policies);
 
             self.changed = Instant::now();
         }
@@ -302,121 +291,147 @@ impl LockedIndex {
     fn reindex_all(&mut self) {
         tracing::debug!("Reindexing all namespaces");
         for ns in self.namespaces.values_mut() {
-            ns.reindex_services(&mut self.servers_by_addr, &self.client_policies);
+            ns.reindex_policies(&self.client_policies);
         }
 
         self.changed = Instant::now();
     }
 }
 
-impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
-    fn apply(&mut self, pod: k8s::Pod) {
-        let ns = pod.namespace().unwrap();
-        let name = pod.name_unchecked();
-        let _span = tracing::info_span!("apply", ns = %ns, %name).entered();
+// impl kubert::index::IndexNamespacedResource<k8s::Pod> for LockedIndex {
+//     fn apply(&mut self, pod: k8s::Pod) {
+//         let ns = pod.namespace().unwrap();
+//         let name = pod.name_unchecked();
+//         let _span = tracing::info_span!("apply", ns = %ns, %name).entered();
 
-        let ns = self
-            .namespaces
-            .entry(ns.clone())
-            .or_insert_with(|| Namespace::new(ns, &self.cluster_info));
-        if let Err(error) =
-            ns.update_pod(name, pod, &self.client_policies, &mut self.servers_by_addr)
-        {
-            tracing::error!(%error, "illegal pod update");
-        }
-    }
+//         let ns = self
+//             .namespaces
+//             .entry(ns.clone())
+//             .or_insert_with(|| Namespace::new(ns, &self.cluster_info));
+//         if let Err(error) =
+//             ns.update_pod(name, pod, &self.client_policies, &mut self.services_by_addr)
+//         {
+//             tracing::error!(%error, "illegal pod update");
+//         }
+//     }
 
-    #[tracing::instrument(name = "delete", fields(%ns, %name))]
-    fn delete(&mut self, ns: String, name: String) {
-        if let Entry::Occupied(mut ns) = self.namespaces.entry(ns) {
-            if let Some(pod) = ns.get_mut().pods.remove(&name) {
-                // if there was a pod, remove its ports from the index of
-                // servers by IP.
-                for addr in pod.addrs() {
-                    self.servers_by_addr.remove(&addr);
-                }
+//     #[tracing::instrument(name = "delete", fields(%ns, %name))]
+//     fn delete(&mut self, ns: String, name: String) {
+//         if let Entry::Occupied(mut ns) = self.namespaces.entry(ns) {
+//             if let Some(pod) = ns.get_mut().pods.remove(&name) {
+//                 // if there was a pod, remove its ports from the index of
+//                 // servers by IP.
+//                 for addr in pod.addrs() {
+//                     self.services_by_addr.remove(&addr);
+//                 }
 
-                // if there are no more pods in the ns, we can also delete the
-                // ns.
-                if ns.get().pods.is_empty() {
-                    tracing::debug!("namespace has no more pods; removing it");
-                    ns.remove();
-                }
-            }
-            tracing::info!("pod deleted");
+//                 // if there are no more pods in the ns, we can also delete the
+//                 // ns.
+//                 if ns.get().pods.is_empty() {
+//                     tracing::debug!("namespace has no more pods; removing it");
+//                     ns.remove();
+//                 }
+//             }
+//             tracing::info!("pod deleted");
 
-            self.changed = Instant::now();
-        } else {
-            tracing::debug!("tried to delete a pod in a namespace that does not exist!");
-        }
-    }
-}
+//             self.changed = Instant::now();
+//         } else {
+//             tracing::debug!("tried to delete a pod in a namespace that does not exist!");
+//         }
+//     }
+// }
 
 impl kubert::index::IndexNamespacedResource<Service> for LockedIndex {
     fn apply(&mut self, svc: Service) {
         let ns = svc.namespace().expect("service must be namespaced");
         let name = svc.name_unchecked();
         let _span = tracing::info_span!("apply", %ns, %name).entered();
-        match service::Spec::from_resource(&self.cluster_info, &ns, svc) {
-            Ok(svc) => {
-                self.ns_or_default_with_reindex(ns, |ns| ns.policies.update_service(name, svc));
+        let svc = match OutboundService::from_resource(&self.cluster_info, ns.clone(), svc) {
+            Ok(svc) => svc,
+            Err(error) => {
+                tracing::warn!(%error, "invalid Service");
+                return;
             }
-            Err(error) => tracing::warn!(%error, "invalid Service {ns}/{name}"),
+        };
+        if let Some(rx) = self.ns_or_default(ns).policies.update_service(name, svc) {
+            for &addr in &rx.borrow().cluster_addrs {
+                match self.services_by_addr.entry(addr) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(rx.clone());
+                    }
+                    Entry::Occupied(entry) => {
+                        assert!(entry.get().same_channel(&rx));
+                    }
+                }
+            }
         }
     }
 
     #[tracing::instrument(name = "delete", skip(self), fields(%ns, %name))]
     fn delete(&mut self, ns: String, name: String) {
-        self.ns_with_reindex(ns, |ns| ns.policies.services.remove(&name).is_some());
+        match self.namespaces.entry(ns) {
+            Entry::Vacant(_) => {
+                tracing::debug!("tried to delete services in a namespace that does not exist!");
+            }
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().policies.services.remove(&name);
+                tracing::info!("deleted service");
+                if entry.get().is_empty() {
+                    tracing::info!("namespace empty");
+                    entry.remove();
+                }
+            }
+        }
     }
 
-    fn reset(&mut self, svcs: Vec<Service>, deleted: AHashMap<String, AHashSet<String>>) {
+    fn reset(&mut self, svcs: Vec<Service>, deleted: HashMap<String, AHashSet<String>>) {
         let _span = tracing::info_span!("reset").entered();
 
-        // Aggregate all of the updates by namespace so that we only reindex
-        // once per namespace.
-        type Ns = NsUpdate<service::Spec>;
-        let mut updates_by_ns = AHashMap::<String, Ns>::default();
         for svc in svcs.into_iter() {
             let ns = svc.namespace().expect("service must be namespaced");
             let name = svc.name_unchecked();
-            match service::Spec::from_resource(&self.cluster_info, &ns, svc) {
-                Ok(service) => updates_by_ns
-                    .entry(ns)
-                    .or_default()
-                    .added
-                    .push((name, service)),
-                Err(error) => tracing::warn!(%error, "invalid Service {ns}/{name}"),
+            let _span = tracing::info_span!("apply", %ns, %name).entered();
+            let svc = match OutboundService::from_resource(&self.cluster_info, ns.clone(), svc) {
+                Ok(svc) => svc,
+                Err(error) => {
+                    tracing::warn!(%error, "invalid Service");
+                    continue;
+                }
+            };
+            if let Some(rx) = self.ns_or_default(ns).policies.update_service(name, svc) {
+                for &addr in &rx.borrow().cluster_addrs {
+                    match self.services_by_addr.entry(addr) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(rx.clone());
+                        }
+                        Entry::Occupied(entry) => {
+                            assert!(entry.get().same_channel(&rx));
+                        }
+                    }
+                }
             }
         }
         for (ns, names) in deleted.into_iter() {
-            updates_by_ns.entry(ns).or_default().removed = names;
-        }
-
-        for (namespace, Ns { added, removed }) in updates_by_ns.into_iter() {
-            if added.is_empty() {
-                // If there are no live resources in the namespace, we do not
-                // want to create a default namespace instance, we just want to
-                // clear out all resources for the namespace (and then drop the
-                // whole namespace, if necessary).
-                self.ns_with_reindex(namespace, |ns| {
-                    ns.policies.services.clear();
-                    true
-                });
-            } else {
-                // Otherwise, we take greater care to reindex only when the
-                // state actually changed. The vast majority of resets will see
-                // no actual data change.
-                self.ns_or_default_with_reindex(namespace, |ns| {
-                    let mut changed = !removed.is_empty();
-                    for name in removed.into_iter() {
-                        ns.policies.services.remove(&name);
+            let _span = tracing::info_span!("delete", %ns).entered();
+            match self.namespaces.entry(ns) {
+                Entry::Vacant(_) => {
+                    tracing::debug!(
+                        ?names,
+                        "tried to delete services in a namespace that does not exist!"
+                    );
+                }
+                Entry::Occupied(mut entry) => {
+                    for service in names {
+                        tracing::info!(
+                            %service, "deleted",
+                        );
+                        entry.get_mut().policies.services.remove(&service);
                     }
-                    for (name, svc) in added.into_iter() {
-                        changed = ns.policies.update_service(name, svc) || changed;
+                    if entry.get().is_empty() {
+                        tracing::info!("namespace empty");
+                        entry.remove();
                     }
-                    changed
-                });
+                }
             }
         }
     }
@@ -580,314 +595,427 @@ impl kubert::index::IndexNamespacedResource<HttpClientPolicy> for LockedIndex {
     }
 }
 
+impl kubert::index::IndexNamespacedResource<ClientPolicyBinding> for LockedIndex {
+    fn apply(&mut self, binding: ClientPolicyBinding) {
+        let ns = binding
+            .namespace()
+            .expect("ClientPolicyBinding must have a namespace");
+        let name = binding.name_unchecked();
+        let _span = tracing::info_span!("apply", %ns, %name).entered();
+        let binding = match client_policy::Binding::try_from(binding) {
+            Ok(spec) => spec,
+            Err(error) => {
+                tracing::warn!(%error, "invalid ClientPolicyBinding");
+                return;
+            }
+        };
+
+        if self.client_policies.update_binding(ns, name, binding) {
+            self.reindex_all()
+        }
+    }
+
+    fn reset(
+        &mut self,
+        policies: Vec<ClientPolicyBinding>,
+        deleted: kubert::index::NamespacedRemoved,
+    ) {
+        let _span = tracing::info_span!("reset").entered();
+        let mut changed = false;
+        for policy in policies.into_iter() {
+            let ns = policy
+                .namespace()
+                .expect("ClientPolicyBinding must have a namespace");
+            let name = policy.name_unchecked();
+            let spec = match client_policy::Binding::try_from(policy) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    tracing::warn!(%ns, %name, %error, "invalid ClientPolicyBinding");
+                    continue;
+                }
+            };
+            changed |= self.client_policies.update_binding(ns, name, spec);
+        }
+        for (ns_name, names) in deleted.into_iter() {
+            let _span = tracing::debug_span!("delete", ns = %ns_name).entered();
+            if let Entry::Occupied(mut ns) = self.client_policies.by_ns.entry(ns_name) {
+                for name in names.into_iter() {
+                    ns.get_mut().policies.remove(&name);
+                    tracing::debug!(%name, "deleting ClientPolicyBinding");
+                }
+                if ns.get().is_empty() {
+                    tracing::debug!("namespace has no client policies, removing it");
+                    ns.remove();
+                }
+            }
+        }
+
+        if changed {
+            self.reindex_all()
+        }
+    }
+
+    #[tracing::instrument(skip(self), fields(%ns, %name))]
+    fn delete(&mut self, ns: String, name: String) {
+        if let Entry::Occupied(mut ns) = self.client_policies.by_ns.entry(ns) {
+            tracing::debug!("deleting HttpClientPolicy");
+            ns.get_mut().policies.remove(&name);
+            if ns.get().is_empty() {
+                tracing::debug!("namespace has no client policies, deleting it");
+                ns.remove();
+            }
+            self.reindex_all();
+        } else {
+            tracing::warn!("namespace already deleted!");
+        }
+    }
+}
+
 impl Namespace {
     fn new(name: String, cluster: &Arc<ClusterInfo>) -> Self {
         let name = Arc::new(name);
         Self {
             name: name.clone(),
-            pods: AHashMap::default(),
+            pods: HashMap::default(),
             policies: PolicyIndex {
                 namespace: name,
                 cluster_info: cluster.clone(),
-                services: AHashMap::default(),
-                http_routes: AHashMap::default(),
+                services: HashMap::default(),
+                http_routes: HashMap::default(),
             },
         }
     }
 
-    fn reindex_services(
-        &mut self,
-        servers_by_addr: &mut ServersByAddr,
-        client_policies: &ClientPolicyNsIndex,
-    ) {
-        let _span = tracing::info_span!("reindex", ns = %self.name).entered();
-        for (name, pod) in &mut self.pods {
-            let _span = tracing::info_span!("reindex_pod", pod = %name).entered();
-            pod.reindex_services(servers_by_addr, client_policies, &mut self.policies)
-        }
+    fn is_empty(&self) -> bool {
+        self.pods.is_empty() && self.policies.is_empty()
     }
 
-    fn update_pod(
-        &mut self,
-        name: String,
-        pod: k8s::Pod,
-        client_policies: &ClientPolicyNsIndex,
-        servers_by_addr: &mut ServersByAddr,
-    ) -> Result<()> {
-        let port_names = pod
-            .spec
-            .as_ref()
-            .map(pod::tcp_ports_by_name)
-            .unwrap_or_default();
-        let probes = pod
-            .spec
-            .as_ref()
-            .map(pod::pod_http_probes)
-            .unwrap_or_default();
-        let meta = pod::Meta::from_metadata(pod.metadata);
-        let ip = pod
-            .status
-            .ok_or_else(|| anyhow::format_err!("pod has no status"))?
-            .pod_ip
-            .ok_or_else(|| anyhow::format_err!("pod has no IP"))?
-            .parse::<IpAddr>()?;
-        let pod = match self.pods.entry(name.clone()) {
-            Entry::Vacant(entry) => {
-                let mut pod = Pod {
-                    meta,
-                    port_names: Default::default(),
-                    port_servers: pod::PortMap::default(),
-                    probes,
-                    ip,
-                };
-                // XXX(eliza): here is where we populate the `servers_by_addr`
-                // map with *all* the pod's default servers. this is different
-                // from what the policy-controller does: when a pod has only the
-                // default servers, the watch sender isn't added to the index
-                // until someone actually looks it up. that would be more
-                // efficient, but...nobody's actually doing lookups right now,
-                // so we populate the map eagerly so that we can generate a
-                // nice-looking table.
-                //
-                // if we end up using this code to serve real lookups, we should
-                // probably create these default servers lazily instead.
-                for &port in port_names.values().flatten() {
-                    let server = pod.default_outbound_server(port, &self.policies.cluster_info);
-                    let rx = pod.set_default_server(port, server);
-                    servers_by_addr.insert(SocketAddr::new(ip, port.into()), rx);
-                }
-                pod.port_names = port_names;
-                Some(entry.insert(pod))
-            }
-
-            Entry::Occupied(entry) => {
-                let pod = entry.into_mut();
-
-                // Pod labels and annotations may change at runtime, but the
-                // port list may not
-                if pod.port_names != port_names {
-                    anyhow::bail!("pod {} port names must not change", name);
-                }
-
-                // If there aren't meaningful changes, then don't bother doing
-                // any more work.
-                if pod.meta == meta && ip == pod.ip {
-                    tracing::debug!(pod = %name, "No changes");
-                    None
+    fn reindex_policies(&mut self, client_policies: &ClientPolicyNsIndex) {
+        let _span = tracing::info_span!("reindex_policies", ns = %self.name).entered();
+        for (name, svc) in &mut self.policies.services {
+            svc.send_if_modified(|svc| {
+                if svc.reindex_policies(client_policies) {
+                    tracing::info!(service = %name, "reindexed policies for");
+                    true
                 } else {
-                    tracing::debug!(pod = %name, "Updating");
-                    pod.meta = meta;
-                    pod.ip = ip;
-                    Some(pod)
+                    false
                 }
-            }
-        };
-
-        match pod {
-            Some(pod) => {
-                tracing::info!("pod updated");
-                pod.reindex_services(servers_by_addr, client_policies, &mut self.policies)
-            }
-            None => {} // no update
-        };
-
-        Ok(())
+            });
+        }
     }
+
+    // fn update_pod(
+    //     &mut self,
+    //     name: String,
+    //     pod: k8s::Pod,
+    //     client_policies: &ClientPolicyNsIndex,
+    //     services_by_addr: &mut ServicesByAddr,
+    // ) -> Result<()> {
+    //     let port_names = pod
+    //         .spec
+    //         .as_ref()
+    //         .map(pod::tcp_ports_by_name)
+    //         .unwrap_or_default();
+    //     let probes = pod
+    //         .spec
+    //         .as_ref()
+    //         .map(pod::pod_http_probes)
+    //         .unwrap_or_default();
+    //     let meta = pod::Meta::from_metadata(pod.metadata);
+    //     let ip = pod
+    //         .status
+    //         .ok_or_else(|| anyhow::format_err!("pod has no status"))?
+    //         .pod_ip
+    //         .ok_or_else(|| anyhow::format_err!("pod has no IP"))?
+    //         .parse::<IpAddr>()?;
+    //     let pod = match self.pods.entry(name.clone()) {
+    //         Entry::Vacant(entry) => {
+    //             let mut pod = Pod {
+    //                 meta,
+    //                 port_names: Default::default(),
+    //                 port_servers: pod::PortMap::default(),
+    //                 probes,
+    //                 ip,
+    //             };
+    //             // XXX(eliza): here is where we populate the `services_by_addr`
+    //             // map with *all* the pod's default servers. this is different
+    //             // from what the policy-controller does: when a pod has only the
+    //             // default servers, the watch sender isn't added to the index
+    //             // until someone actually looks it up. that would be more
+    //             // efficient, but...nobody's actually doing lookups right now,
+    //             // so we populate the map eagerly so that we can generate a
+    //             // nice-looking table.
+    //             //
+    //             // if we end up using this code to serve real lookups, we should
+    //             // probably create these default servers lazily instead.
+    //             for &port in port_names.values().flatten() {
+    //                 let server = pod.default_outbound_server(port, &self.policies.cluster_info);
+    //                 let rx = pod.set_default_server(port, server);
+    //                 services_by_addr.insert(SocketAddr::new(ip, port.into()), rx);
+    //             }
+    //             pod.port_names = port_names;
+    //             Some(entry.insert(pod))
+    //         }
+
+    //         Entry::Occupied(entry) => {
+    //             let pod = entry.into_mut();
+
+    //             // Pod labels and annotations may change at runtime, but the
+    //             // port list may not
+    //             if pod.port_names != port_names {
+    //                 anyhow::bail!("pod {} port names must not change", name);
+    //             }
+
+    //             // If there aren't meaningful changes, then don't bother doing
+    //             // any more work.
+    //             if pod.meta == meta && ip == pod.ip {
+    //                 tracing::debug!(pod = %name, "No changes");
+    //                 None
+    //             } else {
+    //                 tracing::debug!(pod = %name, "Updating");
+    //                 pod.meta = meta;
+    //                 pod.ip = ip;
+    //                 Some(pod)
+    //             }
+    //         }
+    //     };
+
+    //     match pod {
+    //         Some(pod) => {
+    //             tracing::info!("pod updated");
+    //             pod.reindex_services(services_by_addr, client_policies, &mut self.policies)
+    //         }
+    //         None => {} // no update
+    //     };
+
+    //     Ok(())
+    // }
 }
 
-impl Pod {
-    /// Determines the policies for ports on this pod.
-    fn reindex_services(
-        &mut self,
-        servers_by_addr: &mut ServersByAddr,
-        client_policies: &ClientPolicyNsIndex,
-        ns_policies: &mut PolicyIndex,
-    ) {
-        // Keep track of the ports that are already known in the pod so that, after applying server
-        // matches, we can ensure remaining ports are set to the default policy.
-        let mut unmatched_ports = self.port_servers.keys().copied().collect::<pod::PortSet>();
+// impl Pod {
+//     /// Determines the policies for ports on this pod.
+//     fn reindex_services(
+//         &mut self,
+//         services_by_addr: &mut ServicesByAddr,
+//         client_policies: &ClientPolicyNsIndex,
+//         ns_policies: &mut PolicyIndex,
+//     ) {
+//         // Keep track of the ports that are already known in the pod so that, after applying server
+//         // matches, we can ensure remaining ports are set to the default policy.
+//         let mut unmatched_ports = self.port_servers.keys().copied().collect::<pod::PortSet>();
 
-        // Keep track of which ports have been matched to servers to that we can detect when
-        // multiple servers match a single port.
-        //
-        // We start with capacity for the known ports on the pod; but this can grow if servers
-        // select additional ports.
-        let mut matched_ports = pod::PortMap::with_capacity_and_hasher(
-            unmatched_ports.len(),
-            std::hash::BuildHasherDefault::<pod::PortHasher>::default(),
-        );
+//         // Keep track of which ports have been matched to servers to that we can detect when
+//         // multiple servers match a single port.
+//         //
+//         // We start with capacity for the known ports on the pod; but this can grow if servers
+//         // select additional ports.
+//         let mut matched_ports = pod::PortMap::with_capacity_and_hasher(
+//             unmatched_ports.len(),
+//             std::hash::BuildHasherDefault::<pod::PortHasher>::default(),
+//         );
 
-        for (service_name, service) in ns_policies.services.iter() {
-            if service.pod_selector.matches(&self.meta.labels) {
-                for (portname, &port) in &service.ports {
-                    // If the port is already matched to a server, then log a warning and skip
-                    // updating it so it doesn't flap between servers.
-                    if let Some(prior) = matched_ports.get(&port.number) {
-                        tracing::warn!(
-                            port.name = %portname,
-                            port.number,
-                            port.opaque,
-                            server = %prior,
-                            conflict = %service_name,
-                            "Port already matched by another server; skipping"
-                        );
-                        continue;
-                    }
+//         for (service_name, service) in ns_policies.services.iter() {
+//             if service.pod_selector.matches(&self.meta.labels) {
+//                 for (portname, &port) in &service.ports {
+//                     // If the port is already matched to a server, then log a warning and skip
+//                     // updating it so it doesn't flap between servers.
+//                     if let Some(prior) = matched_ports.get(&port.number) {
+//                         tracing::warn!(
+//                             port.name = %portname,
+//                             port.number,
+//                             port.opaque,
+//                             server = %prior,
+//                             conflict = %service_name,
+//                             "Port already matched by another server; skipping"
+//                         );
+//                         continue;
+//                     }
 
-                    let addr = SocketAddr::new(self.ip, port.number.into());
-                    let s = ns_policies.outbound_server(
-                        port,
-                        self,
-                        service_name,
-                        service,
-                        client_policies,
-                    );
-                    let rx = self.update_server(port.number, service_name, s);
-                    match servers_by_addr.entry(addr) {
-                        Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
-                        Entry::Vacant(entry) => {
-                            entry.insert(rx);
-                        }
-                    }
+//                     let addr = SocketAddr::new(self.ip, port.number.into());
+//                     let s = ns_policies.outbound_server(
+//                         port,
+//                         self,
+//                         service_name,
+//                         service,
+//                         client_policies,
+//                     );
+//                     let rx = self.update_server(port.number, service_name, s);
+//                     match services_by_addr.entry(addr) {
+//                         Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
+//                         Entry::Vacant(entry) => {
+//                             entry.insert(rx);
+//                         }
+//                     }
 
-                    matched_ports.insert(port.number, service_name.clone());
-                    unmatched_ports.remove(&port.number);
-                }
-            }
-        }
+//                     matched_ports.insert(port.number, service_name.clone());
+//                     unmatched_ports.remove(&port.number);
+//                 }
+//             }
+//         }
 
-        // Handle ports that don't have a service.
-        for port in unmatched_ports.into_iter() {
-            let addr = SocketAddr::new(self.ip, port.into());
-            let server = self.default_outbound_server(port, &ns_policies.cluster_info);
-            let rx = self.set_default_server(port, server);
-            match servers_by_addr.entry(addr) {
-                Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
-                Entry::Vacant(entry) => {
-                    entry.insert(rx);
-                }
-            }
-        }
-    }
+//         // Handle ports that don't have a service.
+//         for port in unmatched_ports.into_iter() {
+//             let addr = SocketAddr::new(self.ip, port.into());
+//             let server = self.default_outbound_server(port, &ns_policies.cluster_info);
+//             let rx = self.set_default_server(port, server);
+//             match services_by_addr.entry(addr) {
+//                 Entry::Occupied(entry) => assert!(rx.same_channel(entry.get())),
+//                 Entry::Vacant(entry) => {
+//                     entry.insert(rx);
+//                 }
+//             }
+//         }
+//     }
 
-    /// Returns an iterator over all the `SocketAddr`s of this pod's ports.
-    fn addrs(&self) -> impl Iterator<Item = SocketAddr> + '_ {
-        let ports = self.port_servers.keys().chain(self.probes.keys());
-        ports.map(|&port| SocketAddr::new(self.ip, port.into()))
-    }
+//     /// Returns an iterator over all the `SocketAddr`s of this pod's ports.
+//     fn addrs(&self) -> impl Iterator<Item = SocketAddr> + '_ {
+//         let ports = self.port_servers.keys().chain(self.probes.keys());
+//         ports.map(|&port| SocketAddr::new(self.ip, port.into()))
+//     }
 
-    /// Updates a pod-port to use the given named server.
-    ///
-    /// The name is used explicity (and not derived from the `server` itself) to
-    /// ensure that we're not handling a default server.
-    fn update_server(
-        &mut self,
-        port: NonZeroU16,
-        name: &str,
-        server: OutboundService,
-    ) -> watch::Receiver<OutboundService> {
-        let rx = match self.port_servers.entry(port) {
-            Entry::Vacant(entry) => {
-                tracing::trace!(port = %port, server = %name, "Creating server");
-                let (tx, rx) = watch::channel(server);
-                entry
-                    .insert(PodPortServer {
-                        name: Some(name.to_string()),
-                        tx,
-                        rx,
-                    })
-                    .rx
-                    .clone()
-            }
+//     /// Updates a pod-port to use the given named server.
+//     ///
+//     /// The name is used explicity (and not derived from the `server` itself) to
+//     /// ensure that we're not handling a default server.
+//     fn update_server(
+//         &mut self,
+//         port: NonZeroU16,
+//         name: &str,
+//         server: OutboundService,
+//     ) -> watch::Receiver<OutboundService> {
+//         let rx = match self.port_servers.entry(port) {
+//             Entry::Vacant(entry) => {
+//                 tracing::trace!(port = %port, server = %name, "Creating server");
+//                 let (tx, rx) = watch::channel(server);
+//                 entry
+//                     .insert(PodPortServer {
+//                         name: Some(name.to_string()),
+//                         tx,
+//                         rx,
+//                     })
+//                     .rx
+//                     .clone()
+//             }
 
-            Entry::Occupied(mut entry) => {
-                let ps = entry.get_mut();
+//             Entry::Occupied(mut entry) => {
+//                 let ps = entry.get_mut();
 
-                // Avoid sending redundant updates.
-                if ps.name.as_deref() == Some(name) && *ps.rx.borrow() == server {
-                    tracing::trace!(port = %port, server = %name, "Skipped redundant server update");
-                    tracing::trace!(?server);
-                    return ps.rx.clone();
-                }
+//                 // Avoid sending redundant updates.
+//                 if ps.name.as_deref() == Some(name) && *ps.rx.borrow() == server {
+//                     tracing::trace!(port = %port, server = %name, "Skipped redundant server update");
+//                     tracing::trace!(?server);
+//                     return ps.rx.clone();
+//                 }
 
-                // If the port's server previously matched a different server,
-                // this can either mean that multiple servers currently match
-                // the pod:port, or that we're in the middle of an update. We
-                // make the opportunistic choice to assume the cluster is
-                // configured coherently so we take the update. The admission
-                // controller should prevent conflicts.
-                tracing::trace!(port = %port, server = %name, "Updating server");
-                ps.name = Some(name.to_string());
-                ps.tx.send(server).expect("a receiver is held by the index");
-                ps.rx.clone()
-            }
-        };
+//                 // If the port's server previously matched a different server,
+//                 // this can either mean that multiple servers currently match
+//                 // the pod:port, or that we're in the middle of an update. We
+//                 // make the opportunistic choice to assume the cluster is
+//                 // configured coherently so we take the update. The admission
+//                 // controller should prevent conflicts.
+//                 tracing::trace!(port = %port, server = %name, "Updating server");
+//                 ps.name = Some(name.to_string());
+//                 ps.tx.send(server).expect("a receiver is held by the index");
+//                 ps.rx.clone()
+//             }
+//         };
 
-        tracing::debug!(port = %port, server = %name, "Updated server");
-        rx
-    }
+//         tracing::debug!(port = %port, server = %name, "Updated server");
+//         rx
+//     }
 
-    /// Updates a pod-port to use the given named server.
-    fn set_default_server(
-        &mut self,
-        port: NonZeroU16,
-        server: OutboundService,
-    ) -> watch::Receiver<OutboundService> {
-        match self.port_servers.entry(port) {
-            Entry::Vacant(entry) => {
-                tracing::debug!(%port, "Creating default server");
-                let (tx, rx) = watch::channel(server);
-                let rx2 = rx.clone();
-                entry.insert(PodPortServer { name: None, tx, rx });
-                rx2
-            }
+//     /// Updates a pod-port to use the given named server.
+//     fn set_default_server(
+//         &mut self,
+//         port: NonZeroU16,
+//         server: OutboundService,
+//     ) -> watch::Receiver<OutboundService> {
+//         match self.port_servers.entry(port) {
+//             Entry::Vacant(entry) => {
+//                 tracing::debug!(%port, "Creating default server");
+//                 let (tx, rx) = watch::channel(server);
+//                 let rx2 = rx.clone();
+//                 entry.insert(PodPortServer { name: None, tx, rx });
+//                 rx2
+//             }
 
-            Entry::Occupied(mut entry) => {
-                let ps = entry.get_mut();
+//             Entry::Occupied(mut entry) => {
+//                 let ps = entry.get_mut();
 
-                // Avoid sending redundant updates.
-                if *ps.rx.borrow() == server {
-                    tracing::trace!(%port, "Default server already set");
-                    return ps.rx.clone();
-                }
+//                 // Avoid sending redundant updates.
+//                 if *ps.rx.borrow() == server {
+//                     tracing::trace!(%port, "Default server already set");
+//                     return ps.rx.clone();
+//                 }
 
-                tracing::debug!(%port, "Setting default server");
-                ps.name = None;
-                ps.tx.send(server).expect("a receiver is held by the index");
-                ps.rx.clone()
-            }
-        }
-    }
+//                 tracing::debug!(%port, "Setting default server");
+//                 ps.name = None;
+//                 ps.tx.send(server).expect("a receiver is held by the index");
+//                 ps.rx.clone()
+//             }
+//         }
+//     }
 
-    fn probe_paths(&self, port: NonZeroU16) -> impl Iterator<Item = &str> + '_ {
-        self.probes
-            .get(&port)
-            .into_iter()
-            .flatten()
-            .map(|p| p.as_str())
-    }
-    fn default_outbound_server(&self, port: NonZeroU16, config: &ClusterInfo) -> OutboundService {
-        let protocol = if self.meta.settings.opaque_ports.contains(&port) {
-            core::ProxyProtocol::Opaque
-        } else {
-            core::ProxyProtocol::Detect {
-                timeout: config.default_detect_timeout,
-            }
-        };
+//     fn probe_paths(&self, port: NonZeroU16) -> impl Iterator<Item = &str> + '_ {
+//         self.probes
+//             .get(&port)
+//             .into_iter()
+//             .flatten()
+//             .map(|p| p.as_str())
+//     }
+//     fn default_outbound_server(&self, port: NonZeroU16, config: &ClusterInfo) -> OutboundService {
+//         let protocol = if self.meta.settings.opaque_ports.contains(&port) {
+//             core::ProxyProtocol::Opaque
+//         } else {
+//             core::ProxyProtocol::Detect {
+//                 timeout: config.default_detect_timeout,
+//             }
+//         };
 
-        let http_routes = config.default_outbound_http_routes(self.probe_paths(port));
+//         let http_routes = config.default_outbound_http_routes(self.probe_paths(port));
 
-        OutboundService {
-            reference: OutboundServiceRef::Default,
-            fqdn: None,
-            protocol,
-            http_routes,
-            client_policy: None,
-        }
-    }
-}
+//         OutboundService {
+//             reference: OutboundServiceRef::Default,
+//             fqdn: None,
+//             protocol,
+//             http_routes,
+//             client_policy: None,
+//         }
+//     }
+// }
 
 impl PolicyIndex {
+    fn is_empty(&self) -> bool {
+        self.services.is_empty() && self.http_routes.is_empty()
+    }
+
+    fn update_service(
+        &mut self,
+        name: String,
+        service: OutboundService,
+    ) -> Option<watch::Receiver<OutboundService>> {
+        match self.services.entry(name) {
+            Entry::Vacant(entry) => {
+                tracing::debug!(?service, "adding to index");
+                let (tx, rx) = watch::channel(service);
+                entry.insert(tx);
+                Some(rx)
+            }
+            Entry::Occupied(mut entry) => {
+                let entry = entry.get_mut();
+                if *entry.borrow() == service {
+                    tracing::debug!(?service, "no changes");
+                    return None;
+                }
+
+                tracing::debug!(?service, "updating");
+                let rx = entry.subscribe();
+                entry.send(service);
+                Some(rx)
+            }
+        }
+    }
+
     fn update_http_route(&mut self, name: String, route: OutboundRouteBinding) -> bool {
         match self.http_routes.entry(name) {
             Entry::Vacant(entry) => {
@@ -908,125 +1036,125 @@ impl PolicyIndex {
         true
     }
 
-    fn update_service(&mut self, name: String, svc: service::Spec) -> bool {
-        match self.services.entry(name.clone()) {
-            Entry::Vacant(entry) => {
-                entry.insert(svc);
-            }
-            Entry::Occupied(entry) => {
-                let current = entry.into_mut();
-                if *current == svc {
-                    tracing::debug!(service = %name, "no changes");
-                    return false;
-                }
-                tracing::debug!(service = %name, "updating");
-                *current = svc;
-            }
-        }
-        true
-    }
+    // fn update_service(&mut self, name: String, svc: service::Spec) -> bool {
+    //     match self.services.entry(name.clone()) {
+    //         Entry::Vacant(entry) => {
+    //             entry.insert(svc);
+    //         }
+    //         Entry::Occupied(entry) => {
+    //             let current = entry.into_mut();
+    //             if *current == svc {
+    //                 tracing::debug!(service = %name, "no changes");
+    //                 return false;
+    //             }
+    //             tracing::debug!(service = %name, "updating");
+    //             *current = svc;
+    //         }
+    //     }
+    //     true
+    // }
 
-    fn outbound_server(
-        &self,
-        port: service::ServicePort,
-        pod: &Pod,
-        service_name: &str,
-        service: &service::Spec,
-        client_policies: &ClientPolicyNsIndex,
-    ) -> OutboundService {
-        let opaque = port.opaque || pod.meta.settings.opaque_ports.contains(&port.number);
-        tracing::debug!(
-            service = %service_name,
-            port.number,
-            port.opaque = opaque,
-            "Creating outbound server"
-        );
+    // fn outbound_server(
+    //     &self,
+    //     port: service::ServicePort,
+    //     pod: &Pod,
+    //     service_name: &str,
+    //     service: &service::Spec,
+    //     client_policies: &ClientPolicyNsIndex,
+    // ) -> OutboundService {
+    //     let opaque = port.opaque || pod.meta.settings.opaque_ports.contains(&port.number);
+    //     tracing::debug!(
+    //         service = %service_name,
+    //         port.number,
+    //         port.opaque = opaque,
+    //         "Creating outbound server"
+    //     );
 
-        let mut http_routes = self.http_routes(service_name, pod.probe_paths(port.number));
-        let client_policy = self.client_policies(service_name, client_policies, &mut http_routes);
+    //     let mut http_routes = self.http_routes(service_name, pod.probe_paths(port.number));
+    //     let client_policy = self.client_policies(service_name, client_policies, &mut http_routes);
 
-        let protocol = if opaque {
-            core::ProxyProtocol::Opaque
-        } else {
-            core::ProxyProtocol::Detect {
-                timeout: self.cluster_info.default_detect_timeout,
-            }
-        };
+    //     let protocol = if opaque {
+    //         core::ProxyProtocol::Opaque
+    //     } else {
+    //         core::ProxyProtocol::Detect {
+    //             timeout: self.cluster_info.default_detect_timeout,
+    //         }
+    //     };
 
-        OutboundService {
-            reference: OutboundServiceRef::Service(service_name.to_string()),
-            fqdn: Some(service.fqdn.clone()),
-            protocol,
-            http_routes,
-            client_policy,
-        }
-    }
+    //     OutboundService {
+    //         reference: OutboundServiceRef::Service(service_name.to_string()),
+    //         fqdn: Some(service.fqdn.clone()),
+    //         protocol,
+    //         http_routes,
+    //         client_policies,
+    //     }
+    // }
 
-    fn http_routes<'p>(
-        &self,
-        service_name: &str,
-        probe_paths: impl Iterator<Item = &'p str>,
-    ) -> HashMap<core::InboundHttpRouteRef, OutboundHttpRoute> {
-        let routes = self
-            .http_routes
-            .iter()
-            .filter(|(_, route)| route.selects_service(service_name))
-            .map(|(name, route)| {
-                let route = route.route.clone();
-                (core::InboundHttpRouteRef::Linkerd(name.clone()), route)
-            })
-            .collect::<HashMap<_, _>>();
-        if !routes.is_empty() {
-            return routes;
-        }
-        self.cluster_info.default_outbound_http_routes(probe_paths)
-    }
+    // fn http_routes<'p>(
+    //     &self,
+    //     service_name: &str,
+    //     probe_paths: impl Iterator<Item = &'p str>,
+    // ) -> HashMap<core::InboundHttpRouteRef, OutboundHttpRoute> {
+    //     let routes = self
+    //         .http_routes
+    //         .iter()
+    //         .filter(|(_, route)| route.selects_service(service_name))
+    //         .map(|(name, route)| {
+    //             let route = route.route.clone();
+    //             (core::InboundHttpRouteRef::Linkerd(name.clone()), route)
+    //         })
+    //         .collect::<HashMap<_, _>>();
+    //     if !routes.is_empty() {
+    //         return routes;
+    //     }
+    //     self.cluster_info.default_outbound_http_routes(probe_paths)
+    // }
 
-    fn client_policies(
-        &self,
-        service_name: &str,
-        client_policies: &ClientPolicyNsIndex,
-        http_routes: &mut HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
-    ) -> Option<client_policy::Spec> {
-        let mut server_policy = None;
-        let potential_policies = client_policies
-            .all_policies()
-            .filter(|(_, policy)| policy.target_ns() == *self.namespace);
-        let _span = tracing::debug_span!("client_policies", ns = %self.namespace.as_ref(), service = %service_name).entered();
-        for (name, policy) in potential_policies {
-            let _span = tracing::debug_span!("policy", message = %name).entered();
-            if policy.selects_service(self.namespace.as_ref(), service_name) {
-                tracing::debug!("policy selects service");
-                // TODO(eliza): how to handle multiple ClientPolicies selecting
-                // the same service?
-                assert_eq!(
-                    server_policy, None,
-                    "we already found a policy that selects this service!"
-                );
-                server_policy = Some(policy.clone());
-            } else {
-                tracing::debug!("policy does not select service");
-            }
+    // fn client_policies(
+    //     &self,
+    //     service_name: &str,
+    //     client_policies: &ClientPolicyNsIndex,
+    //     http_routes: &mut HashMap<core::InboundHttpRouteRef, OutboundHttpRoute>,
+    // ) -> Option<client_policy::Spec> {
+    //     let mut server_policy = None;
+    //     let potential_policies = client_policies
+    //         .all_policies()
+    //         .filter(|(_, policy)| policy.target_ns() == *self.namespace);
+    //     let _span = tracing::debug_span!("client_policies", ns = %self.namespace.as_ref(), service = %service_name).entered();
+    //     for (name, policy) in potential_policies {
+    //         let _span = tracing::debug_span!("policy", message = %name).entered();
+    //         if policy.selects_service(self.namespace.as_ref(), service_name) {
+    //             tracing::debug!("policy selects service");
+    //             // TODO(eliza): how to handle multiple ClientPolicies selecting
+    //             // the same service?
+    //             assert_eq!(
+    //                 server_policy, None,
+    //                 "we already found a policy that selects this service!"
+    //             );
+    //             server_policy = Some(policy.clone());
+    //         } else {
+    //             tracing::debug!("policy does not select service");
+    //         }
 
-            for (reference, route) in http_routes.iter_mut() {
-                let _span = tracing::debug_span!("route", ?reference).entered();
-                if policy.selects_route(self.namespace.as_ref(), reference) {
-                    tracing::debug!("policy selects route on service");
+    //         for (reference, route) in http_routes.iter_mut() {
+    //             let _span = tracing::debug_span!("route", ?reference).entered();
+    //             if policy.selects_route(self.namespace.as_ref(), reference) {
+    //                 tracing::debug!("policy selects route on service");
 
-                    // TODO(eliza): how to handle multiple ClientPolicies selecting
-                    // the same server?
-                    assert_eq!(
-                        server_policy, None,
-                        "we already found a policy that selects this route!"
-                    );
-                    route.client_policy = Some(policy.clone());
-                } else {
-                    tracing::debug!("policy does not select this route");
-                }
-            }
-        }
-        server_policy
-    }
+    //                 // TODO(eliza): how to handle multiple ClientPolicies selecting
+    //                 // the same server?
+    //                 assert_eq!(
+    //                     server_policy, None,
+    //                     "we already found a policy that selects this route!"
+    //                 );
+    //                 route.client_policy = Some(policy.clone());
+    //             } else {
+    //                 tracing::debug!("policy does not select this route");
+    //             }
+    //         }
+    //     }
+    //     server_policy
+    // }
 }
 
 // === impl ClientPolicyNsIndex ===
@@ -1035,6 +1163,76 @@ impl ClientPolicyNsIndex {
     /// Returns an iterator over all ClientPolicies in the index.
     fn all_policies(&self) -> impl Iterator<Item = (&String, &client_policy::Spec)> + '_ {
         self.by_ns.values().flat_map(|ns| ns.policies.iter())
+    }
+
+    pub fn policies_for<'a>(
+        &'a self,
+        service: &'a OutboundServiceRef,
+    ) -> impl Iterator<Item = (client_policy::PolicyRef, &'a client_policy::Spec)> + 'a {
+        let service = match service {
+            OutboundServiceRef::Service { ns, name } => Some((ns, name)),
+            OutboundServiceRef::Default => None,
+        };
+        service.into_iter().flat_map(|(ns, svc)| {
+            self.by_ns.iter().flat_map(|(policy_ns, index)| {
+                index.policies.iter().filter_map(|(name, policy)| {
+                    if policy.selects_service(ns, svc) {
+                        Some((
+                            client_policy::PolicyRef {
+                                name: name.clone(),
+                                namespace: policy_ns.clone(),
+                            },
+                            policy,
+                        ))
+                    } else {
+                        None
+                    }
+                })
+            })
+        })
+    }
+
+    pub fn bindings_for<'a>(
+        &'a self,
+        svc_policies: &'a HashMap<client_policy::PolicyRef, client_policy::Spec>,
+    ) -> impl Iterator<Item = (client_policy::PolicyRef, client_policy::Bound)> + 'a {
+        self.by_ns.iter().flat_map(|(policy_ns, index)| {
+            index.bindings.iter().filter_map(|(name, binding)| {
+                let policies = binding
+                    .policies
+                    .iter()
+                    .filter_map(|policy| svc_policies.get(&policy).cloned())
+                    .collect::<Vec<_>>();
+
+                // no targets in this binding exist on this service.
+                if policies.is_empty() {
+                    return None;
+                }
+
+                Some((
+                    client_policy::PolicyRef {
+                        name: name.clone(),
+                        namespace: policy_ns.clone(),
+                    },
+                    client_policy::Bound {
+                        client_pod_selector: binding.client_pod_selector.clone(),
+                        policies,
+                    },
+                ))
+            })
+        })
+    }
+
+    /// Returns an iterator over all ClientPolicyBindings in the index.
+    pub fn all_bindings(&self) -> impl Iterator<Item = (&String, &client_policy::Binding)> + '_ {
+        self.by_ns.values().flat_map(|ns| ns.bindings.iter())
+    }
+
+    pub fn policy(
+        &self,
+        client_policy::PolicyRef { namespace, name }: &client_policy::PolicyRef,
+    ) -> Option<&client_policy::Spec> {
+        self.by_ns.get(namespace)?.policies.get(name)
     }
 
     fn update_policy(&mut self, ns: String, name: String, policy: client_policy::Spec) -> bool {
@@ -1055,11 +1253,35 @@ impl ClientPolicyNsIndex {
 
         true
     }
+
+    fn update_binding(
+        &mut self,
+        ns: String,
+        name: String,
+        binding: client_policy::Binding,
+    ) -> bool {
+        match self.by_ns.entry(ns).or_default().bindings.entry(name) {
+            Entry::Vacant(entry) => {
+                tracing::debug!(?binding, "adding to index");
+                entry.insert(binding);
+            }
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == binding {
+                    tracing::debug!(?binding, "no changes");
+                    return false;
+                }
+                tracing::debug!(?binding, "updating");
+                entry.insert(binding);
+            }
+        }
+
+        true
+    }
 }
 
 impl ClientPolicyIndex {
     fn is_empty(&self) -> bool {
-        self.policies.is_empty() // && self.bindings.is_empty()
+        self.policies.is_empty() && self.bindings.is_empty()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,10 +62,9 @@ struct Args {
     #[clap(long, default_value = "all-unauthenticated")]
     default_policy: defaults::DefaultPolicy,
 
-    /// Dump the current state of the index every `dump_interval_secs`, if
-    /// enabled.
+    /// Dump the current state of the index on changes, if enabled.
     #[clap(long)]
-    dump_interval_secs: Option<u64>,
+    dump_index: bool,
 
     /// The cluster domain.
     #[clap(long, default_value = "cluster.local")]
@@ -82,7 +81,7 @@ async fn main() -> Result<()> {
         admin,
         grpc_addr,
         probe_networks,
-        dump_interval_secs,
+        dump_index,
         default_policy,
         cluster_domain,
     } = Args::parse();
@@ -120,8 +119,8 @@ async fn main() -> Result<()> {
 
     let indices = index.spawn_index_tasks(&mut rt);
 
-    if let Some(secs) = dump_interval_secs {
-        index.dump_index(Duration::from_secs(secs));
+    if dump_index {
+        index.dump_index();
     }
 
     tracing::info!(%grpc_addr, "serving ClientPolicy gRPC API");

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -1,29 +1,29 @@
-use crate::{defaults::DefaultPolicy, k8s};
-use ahash::AHashMap;
-use anyhow::{bail, Context, Result};
+// use crate::k8s;
+// use ahash::AHashMap;
+// use anyhow::{bail, Context, Result};
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::HashSet,
     hash::{BuildHasherDefault, Hasher},
     num::NonZeroU16,
 };
 
-/// Holds pod metadata/config that can change.
-#[derive(Debug, PartialEq)]
-pub(crate) struct Meta {
-    /// The pod's labels. Used by `Server` pod selectors.
-    pub labels: k8s::Labels,
+// /// Holds pod metadata/config that can change.
+// #[derive(Debug, PartialEq)]
+// pub(crate) struct Meta {
+//     /// The pod's labels. Used by `Server` pod selectors.
+//     pub labels: k8s::Labels,
 
-    // Pod-specific settings (i.e., derived from annotations).
-    pub settings: Settings,
-}
+//     // Pod-specific settings (i.e., derived from annotations).
+//     pub settings: Settings,
+// }
 
-/// Per-pod settings, as configured by the pod's annotations.
-#[derive(Debug, Default, PartialEq)]
-pub(crate) struct Settings {
-    // pub require_id_ports: PortSet,
-    pub opaque_ports: PortSet,
-    pub default_policy: Option<DefaultPolicy>,
-}
+// /// Per-pod settings, as configured by the pod's annotations.
+// #[derive(Debug, Default, PartialEq)]
+// pub(crate) struct Settings {
+//     // pub require_id_ports: PortSet,
+//     pub opaque_ports: PortSet,
+//     pub default_policy: Option<DefaultPolicy>,
+// }
 
 /// A `HashSet` specialized for ports.
 ///
@@ -35,7 +35,7 @@ pub(crate) type PortSet = HashSet<NonZeroU16, BuildHasherDefault<PortHasher>>;
 ///
 /// Because ports are `NonZeroU16` values, this type avoids the overhead of
 /// actually hashing ports.
-pub(crate) type PortMap<V> = HashMap<NonZeroU16, V, BuildHasherDefault<PortHasher>>;
+// pub(crate) type PortMap<V> = HashMap<NonZeroU16, V, BuildHasherDefault<PortHasher>>;
 
 /// A hasher for ports.
 ///
@@ -48,16 +48,16 @@ pub(crate) struct PortHasher(u16);
 
 // === impl Meta ===
 
-impl Meta {
-    pub(crate) fn from_metadata(meta: k8s::ObjectMeta) -> Self {
-        let settings = Settings::from_metadata(&meta);
-        tracing::trace!(?settings);
-        Self {
-            settings,
-            labels: meta.labels.into(),
-        }
-    }
-}
+// impl Meta {
+//     pub(crate) fn from_metadata(meta: k8s::ObjectMeta) -> Self {
+//         let settings = Settings::from_metadata(&meta);
+//         tracing::trace!(?settings);
+//         Self {
+//             settings,
+//             labels: meta.labels.into(),
+//         }
+//     }
+// }
 
 // === impl PortHasher ===
 
@@ -77,158 +77,158 @@ impl Hasher for PortHasher {
     }
 }
 
-pub(crate) fn tcp_ports_by_name(spec: &k8s::PodSpec) -> AHashMap<String, PortSet> {
-    let mut ports = AHashMap::<String, PortSet>::default();
-    for (port, name) in spec
-        .containers
-        .iter()
-        .flat_map(|c| c.ports.iter().flatten())
-        .filter_map(named_tcp_port)
-    {
-        ports.entry(name.to_string()).or_default().insert(port);
-    }
-    ports
-}
+// pub(crate) fn tcp_ports_by_name(spec: &k8s::PodSpec) -> AHashMap<String, PortSet> {
+//     let mut ports = AHashMap::<String, PortSet>::default();
+//     for (port, name) in spec
+//         .containers
+//         .iter()
+//         .flat_map(|c| c.ports.iter().flatten())
+//         .filter_map(named_tcp_port)
+//     {
+//         ports.entry(name.to_string()).or_default().insert(port);
+//     }
+//     ports
+// }
 
-/// Gets the container probe ports for a Pod.
-///
-/// The result is a mapping for each probe port exposed by a container in the
-/// Pod and the paths for which probes are expected.
-pub(crate) fn pod_http_probes(pod: &k8s::PodSpec) -> PortMap<BTreeSet<String>> {
-    let mut probes = PortMap::<BTreeSet<String>>::default();
-    for (port, path) in pod.containers.iter().flat_map(container_http_probe_paths) {
-        probes.entry(port).or_default().insert(path);
-    }
-    probes
-}
+// /// Gets the container probe ports for a Pod.
+// ///
+// /// The result is a mapping for each probe port exposed by a container in the
+// /// Pod and the paths for which probes are expected.
+// pub(crate) fn pod_http_probes(pod: &k8s::PodSpec) -> PortMap<BTreeSet<String>> {
+//     let mut probes = PortMap::<BTreeSet<String>>::default();
+//     for (port, path) in pod.containers.iter().flat_map(container_http_probe_paths) {
+//         probes.entry(port).or_default().insert(path);
+//     }
+//     probes
+// }
 
-fn container_http_probe_paths(
-    container: &k8s::Container,
-) -> impl Iterator<Item = (NonZeroU16, String)> + '_ {
-    fn find_by_name(name: &str, ports: &[k8s::ContainerPort]) -> Option<NonZeroU16> {
-        for (p, n) in ports.iter().filter_map(named_tcp_port) {
-            if n.eq_ignore_ascii_case(name) {
-                return Some(p);
-            }
-        }
-        None
-    }
+// fn container_http_probe_paths(
+//     container: &k8s::Container,
+// ) -> impl Iterator<Item = (NonZeroU16, String)> + '_ {
+//     fn find_by_name(name: &str, ports: &[k8s::ContainerPort]) -> Option<NonZeroU16> {
+//         for (p, n) in ports.iter().filter_map(named_tcp_port) {
+//             if n.eq_ignore_ascii_case(name) {
+//                 return Some(p);
+//             }
+//         }
+//         None
+//     }
 
-    fn get_port(port: &k8s::IntOrString, container: &k8s::Container) -> Option<NonZeroU16> {
-        match port {
-            k8s::IntOrString::Int(p) => u16::try_from(*p).ok()?.try_into().ok(),
-            k8s::IntOrString::String(n) => find_by_name(n, container.ports.as_ref()?),
-        }
-    }
+//     fn get_port(port: &k8s::IntOrString, container: &k8s::Container) -> Option<NonZeroU16> {
+//         match port {
+//             k8s::IntOrString::Int(p) => u16::try_from(*p).ok()?.try_into().ok(),
+//             k8s::IntOrString::String(n) => find_by_name(n, container.ports.as_ref()?),
+//         }
+//     }
 
-    (container.liveness_probe.iter())
-        .chain(container.readiness_probe.iter())
-        .chain(container.startup_probe.iter())
-        .filter_map(|p| {
-            let probe = p.http_get.as_ref()?;
-            let port = get_port(&probe.port, container)?;
-            let path = probe.path.clone().unwrap_or_else(|| "/".to_string());
-            Some((port, path))
-        })
-}
+//     (container.liveness_probe.iter())
+//         .chain(container.readiness_probe.iter())
+//         .chain(container.startup_probe.iter())
+//         .filter_map(|p| {
+//             let probe = p.http_get.as_ref()?;
+//             let port = get_port(&probe.port, container)?;
+//             let path = probe.path.clone().unwrap_or_else(|| "/".to_string());
+//             Some((port, path))
+//         })
+// }
 
-fn named_tcp_port(port: &k8s::ContainerPort) -> Option<(NonZeroU16, &str)> {
-    if let Some(ref proto) = port.protocol {
-        if !proto.eq_ignore_ascii_case("TCP") {
-            return None;
-        }
-    }
-    let p = u16::try_from(port.container_port)
-        .and_then(NonZeroU16::try_from)
-        .ok()?;
-    let n = port.name.as_deref()?;
-    Some((p, n))
-}
+// fn named_tcp_port(port: &k8s::ContainerPort) -> Option<(NonZeroU16, &str)> {
+//     if let Some(ref proto) = port.protocol {
+//         if !proto.eq_ignore_ascii_case("TCP") {
+//             return None;
+//         }
+//     }
+//     let p = u16::try_from(port.container_port)
+//         .and_then(NonZeroU16::try_from)
+//         .ok()?;
+//     let n = port.name.as_deref()?;
+//     Some((p, n))
+// }
 
-impl Settings {
-    /// Reads pod settings from the pod metadata including:
-    ///
-    /// - Opaque ports
-    /// - Ports that require identity
-    /// - The pod's default policy
-    pub(crate) fn from_metadata(meta: &k8s::ObjectMeta) -> Self {
-        let anns = match meta.annotations.as_ref() {
-            None => return Self::default(),
-            Some(anns) => anns,
-        };
+// impl Settings {
+//     /// Reads pod settings from the pod metadata including:
+//     ///
+//     /// - Opaque ports
+//     /// - Ports that require identity
+//     /// - The pod's default policy
+//     pub(crate) fn from_metadata(meta: &k8s::ObjectMeta) -> Self {
+//         let anns = match meta.annotations.as_ref() {
+//             None => return Self::default(),
+//             Some(anns) => anns,
+//         };
 
-        let default_policy = default_policy(anns).unwrap_or_else(|error| {
-            tracing::warn!(%error, "invalid default policy annotation value");
-            None
-        });
+//         let default_policy = default_policy(anns).unwrap_or_else(|error| {
+//             tracing::warn!(%error, "invalid default policy annotation value");
+//             None
+//         });
 
-        let opaque_ports = ports_annotation(anns, "config.linkerd.io/opaque-ports");
-        // let require_id_ports = ports_annotation(
-        //     anns,
-        //     "config.linkerd.io/proxy-require-identity-inbound-ports",
-        // );
+//         let opaque_ports = ports_annotation(anns, "config.linkerd.io/opaque-ports");
+//         // let require_id_ports = ports_annotation(
+//         //     anns,
+//         //     "config.linkerd.io/proxy-require-identity-inbound-ports",
+//         // );
 
-        Self {
-            default_policy,
-            opaque_ports,
-            // require_id_ports,
-        }
-    }
-}
+//         Self {
+//             default_policy,
+//             opaque_ports,
+//             // require_id_ports,
+//         }
+//     }
+// }
 
-/// Attempts to read a default policy override from an annotation map.
-fn default_policy(
-    ann: &std::collections::BTreeMap<String, String>,
-) -> Result<Option<DefaultPolicy>> {
-    if let Some(v) = ann.get("config.linkerd.io/default-inbound-policy") {
-        let mode = v.parse()?;
-        return Ok(Some(mode));
-    }
+// /// Attempts to read a default policy override from an annotation map.
+// fn default_policy(
+//     ann: &std::collections::BTreeMap<String, String>,
+// ) -> Result<Option<DefaultPolicy>> {
+//     if let Some(v) = ann.get("config.linkerd.io/default-inbound-policy") {
+//         let mode = v.parse()?;
+//         return Ok(Some(mode));
+//     }
 
-    Ok(None)
-}
+//     Ok(None)
+// }
 
-/// Reads `annotation` from the provided set of annotations, parsing it as a port set.  If the
-/// annotation is not set or is invalid, the empty set is returned.
-fn ports_annotation(
-    annotations: &std::collections::BTreeMap<String, String>,
-    annotation: &str,
-) -> PortSet {
-    annotations
-        .get(annotation)
-        .map(|spec| {
-            parse_portset(spec).unwrap_or_else(|error| {
-                tracing::info!(%spec, %error, %annotation, "Invalid ports list");
-                Default::default()
-            })
-        })
-        .unwrap_or_default()
-}
+// /// Reads `annotation` from the provided set of annotations, parsing it as a port set.  If the
+// /// annotation is not set or is invalid, the empty set is returned.
+// fn ports_annotation(
+//     annotations: &std::collections::BTreeMap<String, String>,
+//     annotation: &str,
+// ) -> PortSet {
+//     annotations
+//         .get(annotation)
+//         .map(|spec| {
+//             parse_portset(spec).unwrap_or_else(|error| {
+//                 tracing::info!(%spec, %error, %annotation, "Invalid ports list");
+//                 Default::default()
+//             })
+//         })
+//         .unwrap_or_default()
+// }
 
-/// Read a comma-separated of ports or port ranges from the given string.
-fn parse_portset(s: &str) -> Result<PortSet> {
-    let mut ports = PortSet::default();
+// /// Read a comma-separated of ports or port ranges from the given string.
+// fn parse_portset(s: &str) -> Result<PortSet> {
+//     let mut ports = PortSet::default();
 
-    for spec in s.split(',') {
-        match spec.split_once('-') {
-            None => {
-                if !spec.trim().is_empty() {
-                    let port = spec.trim().parse().context("parsing port")?;
-                    ports.insert(port);
-                }
-            }
-            Some((floor, ceil)) => {
-                let floor = floor.trim().parse::<NonZeroU16>().context("parsing port")?;
-                let ceil = ceil.trim().parse::<NonZeroU16>().context("parsing port")?;
-                if floor > ceil {
-                    bail!("Port range must be increasing");
-                }
-                ports.extend(
-                    (u16::from(floor)..=u16::from(ceil)).map(|p| NonZeroU16::try_from(p).unwrap()),
-                );
-            }
-        }
-    }
+//     for spec in s.split(',') {
+//         match spec.split_once('-') {
+//             None => {
+//                 if !spec.trim().is_empty() {
+//                     let port = spec.trim().parse().context("parsing port")?;
+//                     ports.insert(port);
+//                 }
+//             }
+//             Some((floor, ceil)) => {
+//                 let floor = floor.trim().parse::<NonZeroU16>().context("parsing port")?;
+//                 let ceil = ceil.trim().parse::<NonZeroU16>().context("parsing port")?;
+//                 if floor > ceil {
+//                     bail!("Port range must be increasing");
+//                 }
+//                 ports.extend(
+//                     (u16::from(floor)..=u16::from(ceil)).map(|p| NonZeroU16::try_from(p).unwrap()),
+//                 );
+//             }
+//         }
+//     }
 
-    Ok(ports)
-}
+//     Ok(ports)
+// }

--- a/src/route.rs
+++ b/src/route.rs
@@ -13,7 +13,7 @@ pub struct OutboundHttpRoute {
     pub hostnames: Vec<HostMatch>,
     // TODO(eliza): need a separate outbound rule type eventually...
     pub rules: Vec<InboundHttpRouteRule>,
-    pub client_policy: Option<client_policy::Spec>,
+    pub client_policies: client_policy::PolicySet,
 
     /// This is required for ordering returned `HttpRoute`s by their creation
     /// timestamp.
@@ -75,7 +75,7 @@ impl TryFrom<policy::HttpRoute> for OutboundRouteBinding {
                 hostnames,
                 rules,
                 creation_timestamp,
-                client_policy: None,
+                client_policies: Default::default(),
             },
         })
     }


### PR DESCRIPTION
This branch rewrites the index in order to implement
ClientPolicyBinding. Now, rather than indexing pods as the "primary"
indexed object, we make Services the primary object in the index. An
`OutboundService` now tracks the ClientPolicyBindings for its
HTTPClientPolicies, and the routes on that service track their bindings.
This way, when we have a watch on an `OutboundService`, we can determine
which policies on that service apply to a particular client based on the
binding's pod selector.

Policies are now only bound to service ClusterIPs.

Pod indexing is temporarily removed. The next step will be to put back
pod indexing so that we can determine which policies apply to a client's
workload identifier. Each connection to the client policy controller's
discovery endpoint will hold a watch on the `OutboundService` for the
requested address, and the pod metadata for the client. Then, whenever
the `OutboundService` watch is updated, we'll determine which policies
apply to that client and send them to the proxy that opened the lookup.

Sample index state:


| ADDRESS            | SERVICE                          | FQDN                                               | POLICY BINDINGS                                                                                                                                          |
|--------------------|----------------------------------|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| 10.43.58.223:7001  | booksapp/authors                 | authors.booksapp.svc.cluster.local                 | authors-get-route/authors:                                                                                                                               |
|                    |                                  |                                                    | - selector: `Selector { match_labels: None, match_expressions: Some([Expression { key: "app", operator: NotIn, values: Some({}) }]) }`                   |
|                    |                                  |                                                    | - policy: `Spec { name: "authors-get", target: HttpRoute { name: "authors-get-route", namespace: "booksapp" }, failure_classification:                   |
|                    |                                  |                                                    | HttpFailureClassification { statuses: ["401", "402", "500-599"] }, filters: [Timeout(500ms)] }`                                                          |
| 10.43.3.255:80     | kube-system/traefik              | traefik.kube-system.svc.cluster.local              |                                                                                                                                                          |
| 10.43.19.38:443    | linkerd/linkerd-sp-validator     | linkerd-sp-validator.linkerd.svc.cluster.local     |                                                                                                                                                          |
| 10.43.0.10:9153    | kube-system/kube-dns             | kube-dns.kube-system.svc.cluster.local             |                                                                                                                                                          |
| 10.43.135.243:7002 | booksapp/books                   | books.booksapp.svc.cluster.local                   | svc/books:                                                                                                                                               |
|                    |                                  |                                                    | - selector: `Selector { match_labels: None, match_expressions: Some([Expression { key: "app", operator: NotIn, values: Some({}) }]) }`                   |
|                    |                                  |                                                    | - policy: `Spec { name: "books", target: Service { name: "books", namespace: "booksapp" }, failure_classification: HttpFailureClassification { statuses: |
|                    |                                  |                                                    | ["401", "402", "503", "500-599"] }, filters: [Timeout(1s)] }`                                                                                            |
| 10.43.36.193:8086  | linkerd/linkerd-dst              | linkerd-dst.linkerd.svc.cluster.local              |                                                                                                                                                          |
| 10.43.17.163:443   | linkerd/linkerd-proxy-injector   | linkerd-proxy-injector.linkerd.svc.cluster.local   |                                                                                                                                                          |
| 10.43.90.211:7000  | booksapp/webapp                  | webapp.booksapp.svc.cluster.local                  |                                                                                                                                                          |
| 10.43.3.255:443    | kube-system/traefik              | traefik.kube-system.svc.cluster.local              |                                                                                                                                                          |
| 10.43.88.98:443    | kube-system/metrics-server       | metrics-server.kube-system.svc.cluster.local       |                                                                                                                                                          |
| 10.43.28.174:8080  | linkerd/linkerd-identity         | linkerd-identity.linkerd.svc.cluster.local         |                                                                                                                                                          |
| 10.43.224.246:443  | linkerd/linkerd-policy-validator | linkerd-policy-validator.linkerd.svc.cluster.local |                                                                                                                                                          |
| 10.43.0.1:443      | default/kubernetes               | kubernetes.default.svc.cluster.local               |                                                                                                                                                          |
| 10.43.0.10:53      | kube-system/kube-dns             | kube-dns.kube-system.svc.cluster.local             |                                                                                                                                                          |

| NAMESPACE | POLICY      | TARGET                               | FAILURE CLASSIFICATION                                                     | FILTERS            |
|-----------|-------------|--------------------------------------|----------------------------------------------------------------------------|--------------------|
| booksapp  | authors-get | HTTPRoute booksapp/authors-get-route | `HttpFailureClassification { statuses: ["401", "402", "500-599"] }`        | `[Timeout(500ms)]` |
| booksapp  | books       | Service booksapp/books               | `HttpFailureClassification { statuses: ["401", "402", "503", "500-599"] }` | `[Timeout(1s)]`    |

(side note, I also changed the index-dumping code to output a Markdown table)