### PR TITLE
change ClientPolicies to target Service ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -2061,6 +2062,8 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
+ "futures",
+ "futures-task",
  "pin-project",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ serde = "1"
 serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
-async-stream = "0.3"
+tracing-futures = { version = "0.2.5", features = ["futures-03", "std-future"] }
+async-stream = "0.3.3"
 async-trait = "0.1"
 drain = "0.1"
 hyper = { version = "0.14", features = ["http2", "server", "tcp"] }

--- a/examples/books-binding.yml
+++ b/examples/books-binding.yml
@@ -10,6 +10,6 @@ spec:
       namespace: booksapp
       name: books
   podSelector:
-    matchExpressions:
-      - { key: app, operator: NotIn, values: [] }
+    matchLabels:
+      app: books
 

--- a/examples/books-binding.yml
+++ b/examples/books-binding.yml
@@ -3,6 +3,7 @@ apiVersion: policy.linkerd.io/v1alpha1
 kind: ClientPolicyBinding
 metadata:
   name: books
+  namespace: booksapp
 spec:
   policyRefs:
     - group: policy.linkerd.io
@@ -11,5 +12,5 @@ spec:
       name: books
   podSelector:
     matchLabels:
-      app: books
+      project: booksapp
 

--- a/examples/books-clientpolicy.yml
+++ b/examples/books-clientpolicy.yml
@@ -7,6 +7,7 @@ spec:
     name: books
     kind: Service
     namespace: booksapp
+    port: service
   failureClassification:
     statuses:
       - "401"

--- a/examples/booksapp/authors-get.yml
+++ b/examples/booksapp/authors-get.yml
@@ -12,6 +12,7 @@ spec:
     - name: authors
       kind: Service
       group: core
+      port: service
   rules:
     - matches:
       - path:

--- a/examples/booksapp/authors-modify.yml
+++ b/examples/booksapp/authors-modify.yml
@@ -12,6 +12,7 @@ spec:
     - name: authors
       kind: Service
       group: core
+      port: service
   rules:
     - matches:
       - path:

--- a/examples/clientpolicy.yml
+++ b/examples/clientpolicy.yml
@@ -8,6 +8,7 @@ spec:
     kind: HTTPRoute
     group: policy.linkerd.io
     namespace: booksapp
+    port: service
   failureClassification:
     statuses:
       - "401"

--- a/examples/clientpolicybinding.yml
+++ b/examples/clientpolicybinding.yml
@@ -12,7 +12,7 @@ spec:
     - group: policy.linkerd.io
       kind: HTTPClientPolicy
       namespace: booksapp
-      name: authors-delete
+      name: authors-modify
     - group: policy.linkerd.io
       kind: HTTPClientPolicy
       namespace: booksapp

--- a/k8s/api/src/client_policy.rs
+++ b/k8s/api/src/client_policy.rs
@@ -1,5 +1,4 @@
-use linkerd_policy_controller_k8s_api::policy::NamespacedTargetRef;
-
+use super::NamespacedTargetRef;
 #[derive(
     Clone, Debug, kube::CustomResource, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
 )]

--- a/k8s/api/src/client_policy_binding.rs
+++ b/k8s/api/src/client_policy_binding.rs
@@ -1,4 +1,5 @@
-use linkerd_policy_controller_k8s_api::{labels, policy::NamespacedTargetRef};
+use super::NamespacedTargetRef;
+use linkerd_policy_controller_k8s_api::labels;
 
 #[derive(
     Clone, Debug, kube::CustomResource, serde::Deserialize, serde::Serialize, schemars::JsonSchema,

--- a/k8s/api/src/lib.rs
+++ b/k8s/api/src/lib.rs
@@ -1,2 +1,124 @@
 pub mod client_policy;
 pub mod client_policy_binding;
+
+// modified from the upstream `linkerd-policy-controller-k8s-api` version of
+// `NamespacedTargetRef`, in order to allow an optional port.
+#[derive(
+    Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, schemars::JsonSchema,
+)]
+pub struct NamespacedTargetRef {
+    pub group: Option<String>,
+    pub kind: String,
+    pub name: String,
+    pub namespace: Option<String>,
+    pub port: Option<String>,
+}
+
+impl NamespacedTargetRef {
+    pub fn from_resource<T>(resource: &T) -> Self
+    where
+        T: kube::Resource,
+        T::DynamicType: Default,
+    {
+        let (group, kind, name) = group_kind_name(resource);
+        let namespace = resource.meta().namespace.clone();
+        Self {
+            group,
+            kind,
+            name,
+            namespace,
+            port: None,
+        }
+    }
+
+    /// Returns the target ref kind, qualified by its group, if necessary.
+    pub fn canonical_kind(&self) -> String {
+        canonical_kind(self.group.as_deref(), &self.kind)
+    }
+
+    /// Checks whether the target references the given resource type
+    pub fn targets_kind<T>(&self) -> bool
+    where
+        T: kube::Resource,
+        T::DynamicType: Default,
+    {
+        targets_kind::<T>(self.group.as_deref(), &self.kind)
+    }
+
+    /// Checks whether the target references the given namespaced resource
+    pub fn targets<T>(&self, resource: &T, local_ns: &str) -> bool
+    where
+        T: kube::Resource,
+        T::DynamicType: Default,
+    {
+        if !self.targets_kind::<T>() {
+            return false;
+        }
+
+        // If the resource specifies a namespace other than the target or the
+        // default namespace, that's a deal-breaker.
+        let tns = self.namespace.as_deref().unwrap_or(local_ns);
+        match resource.meta().namespace.as_deref() {
+            Some(rns) if rns.eq_ignore_ascii_case(tns) => {}
+            _ => return false,
+        };
+
+        match resource.meta().name.as_deref() {
+            None => return false,
+            Some(rname) => {
+                if !self.name.eq_ignore_ascii_case(rname) {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+}
+
+fn canonical_kind(group: Option<&str>, kind: &str) -> String {
+    if let Some(group) = group {
+        format!("{}.{}", kind, group)
+    } else {
+        kind.to_string()
+    }
+}
+
+fn group_kind_name<T>(resource: &T) -> (Option<String>, String, String)
+where
+    T: kube::Resource,
+    T::DynamicType: Default,
+{
+    let dt = Default::default();
+
+    let group = match T::group(&dt) {
+        g if (*g).is_empty() => None,
+        g => Some(g.to_string()),
+    };
+
+    let kind = T::kind(&dt).to_string();
+
+    let name = resource
+        .meta()
+        .name
+        .clone()
+        .expect("resource must have a name");
+
+    (group, kind, name)
+}
+
+fn targets_kind<T>(group: Option<&str>, kind: &str) -> bool
+where
+    T: kube::Resource,
+    T::DynamicType: Default,
+{
+    let dt = Default::default();
+
+    let mut t_group = &*T::group(&dt);
+    if t_group.is_empty() {
+        t_group = "core";
+    }
+
+    group.unwrap_or("core").eq_ignore_ascii_case(t_group)
+        && kind.eq_ignore_ascii_case(&*T::kind(&dt))
+}

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -157,7 +157,7 @@ impl TryFrom<ClientPolicyBinding> for Binding {
             .ok_or_else(|| anyhow!("ClientPolicyBinding must be namespaced"))?;
         let name = binding.name_unchecked();
         let policy_refs = binding.spec.policy_refs.into_iter().map(|policy_ref| {
-            ensure!(policy_ref.targets_kind::<HttpClientPolicy>(), "ClientPolicyBinding {name} included a policy ref that does not target an HTTPClientPolicy!");
+            ensure!(policy_ref.targets_kind::<HttpClientPolicy>(), "ClientPolicyBinding {name} included a policy ref {policy_ref:?} that does not target an HTTPClientPolicy!");
             Ok(PolicyRef {
                 name: policy_ref.name,
                 namespace: policy_ref.namespace.unwrap_or_else(|| ns.clone()),

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -1,6 +1,7 @@
 use crate::{
     core, index,
     k8s::{self, policy::HttpRoute},
+    pod,
 };
 use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use anyhow::{anyhow, ensure, Context, Error};
@@ -271,6 +272,15 @@ impl PolicySet {
         }
 
         changed
+    }
+
+    /// Returns the policies in this policy set that are bound to the given
+    /// `pod`.
+    pub fn policies_for<'a>(&'a self, pod: &'a pod::Meta) -> impl Iterator<Item = &Spec> + 'a {
+        self.bindings
+            .values()
+            .filter(move |binding| binding.client_pod_selector.matches(&pod.labels))
+            .flat_map(|binding| binding.policies.iter())
     }
 }
 

--- a/src/client_policy.rs
+++ b/src/client_policy.rs
@@ -235,6 +235,7 @@ impl PolicySet {
                 }
             }
         }
+
         for policy in unmatched_policies {
             tracing::debug!(policy.ns = %policy.namespace, %policy.name, "removed policy");
             self.policies.remove(&policy);
@@ -281,6 +282,10 @@ impl PolicySet {
             .values()
             .filter(move |binding| binding.client_pod_selector.matches(&pod.labels))
             .flat_map(|binding| binding.policies.iter())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty() && self.policies.is_empty()
     }
 }
 

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -71,7 +71,7 @@ impl ClientPolicies for Server {
         let port = NonZeroU16::new(addr.port())
             .ok_or_else(|| tonic::Status::invalid_argument("port must not be zero"))?;
         let stream = async_stream::stream! {
-
+            tracing::debug!("started get_client_policy stream");
             loop {
                 let update = {
                     let pod = pod_watch.borrow_and_update();

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -22,6 +22,7 @@ use linkerd_policy_controller_core::{
     InboundHttpRouteRef,
 };
 use std::{net::SocketAddr, num::NonZeroU16};
+use tracing_futures::Instrument;
 
 #[derive(Clone, Debug)]
 pub struct Server {
@@ -69,20 +70,16 @@ impl ClientPolicies for Server {
             .map_err(|err| tonic::Status::not_found(err.to_string()))?;
         let port = NonZeroU16::new(addr.port())
             .ok_or_else(|| tonic::Status::invalid_argument("port must not be zero"))?;
-        Ok(tonic::Response::new(Box::pin(async_stream::stream! {
+        let stream = async_stream::stream! {
 
             loop {
                 let update = {
                     let pod = pod_watch.borrow_and_update();
                     let svc = svc_watch.borrow_and_update();
 
-                    // is there a service-level policy for this port that's
-                    // bound to the client pod?
-                    let svc_policy = svc.svc_policy_for(port, &*pod);
-                    tracing::info!(?svc_policy);
                     // TODO(eliza): do the same for route policies...
 
-                    to_client_policy(&svc, &pod)
+                    to_client_policy(&svc, port, &pod)
                 };
 
                 yield update;
@@ -93,12 +90,16 @@ impl ClientPolicies for Server {
                     _ = pod_watch.changed() => {},
                 }
             }
-        })))
+        };
+        Ok(tonic::Response::new(Box::pin(stream.instrument(
+            tracing::debug_span!("get_client_policy", %addr, ?context.pod, ?context.ns),
+        ))))
     }
 }
 
 fn to_client_policy(
     svc: &OutboundService,
+    port: NonZeroU16,
     pod: &Meta,
 ) -> Result<proto::ClientPolicy, tonic::Status> {
     let http_routes = svc
@@ -106,6 +107,16 @@ fn to_client_policy(
         .iter()
         .map(|(route_ref, route)| to_http_route(route_ref, route, pod))
         .collect::<Result<_, _>>()?;
+
+    // is there a service-level policy for this port that's
+    // bound to the client pod?
+    let filters = match svc.policies_for_port(port) {
+        Some(policies) => to_filters(policies, pod)?,
+        None => {
+            tracing::debug!(port, "no client policies for this service target port");
+            Vec::new()
+        }
+    };
 
     Ok(proto::ClientPolicy {
         fully_qualified_name: svc.fqdn.as_ref().map(|s| s.to_string()).unwrap_or_default(),
@@ -116,7 +127,7 @@ fn to_client_policy(
                 http_routes,
             })),
         }),
-        filters: to_filters(&svc.client_policies, pod)?,
+        filters,
     })
 }
 
@@ -141,7 +152,7 @@ fn to_http_route(
         }),
     };
 
-    let hosts = hostnames.into_iter().map(convert_host_match).collect();
+    let hosts = hostnames.iter().map(convert_host_match).collect();
 
     let rules = rules
         .iter()
@@ -169,11 +180,11 @@ fn convert_host_match(h: &HostMatch) -> http_route::HostMatch {
 }
 
 fn to_filters(policies: &PolicySet, pod: &Meta) -> Result<Vec<proto::Filter>, tonic::Status> {
+    // TODO(eliza): also find route policies
+
     let filters = policies
-        .bindings
-        .values()
-        .filter(|binding| binding.client_pod_selector.matches(&pod.labels))
-        .flat_map(|binding| binding.policies.iter().flat_map(|spec| spec.filters.iter()))
+        .policies_for(pod)
+        .flat_map(|spec| spec.filters.iter())
         .map(convert_filter)
         .collect::<Result<_, _>>()?;
     Ok(filters)

--- a/src/pod.rs
+++ b/src/pod.rs
@@ -1,6 +1,6 @@
 use crate::k8s;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     hash::{BuildHasherDefault, Hasher},
     num::NonZeroU16,
 };
@@ -30,7 +30,7 @@ pub(crate) type PortSet = HashSet<NonZeroU16, BuildHasherDefault<PortHasher>>;
 ///
 /// Because ports are `NonZeroU16` values, this type avoids the overhead of
 /// actually hashing ports.
-// pub(crate) type PortMap<V> = HashMap<NonZeroU16, V, BuildHasherDefault<PortHasher>>;
+pub(crate) type PortMap<V> = HashMap<NonZeroU16, V, BuildHasherDefault<PortHasher>>;
 
 /// A hasher for ports.
 ///

--- a/src/service.rs
+++ b/src/service.rs
@@ -98,31 +98,7 @@ impl OutboundService {
         Ok(svc)
     }
 
-    pub fn svc_policy_for(
-        &self,
-        port: NonZeroU16,
-        pod: &pod::Meta,
-    ) -> Option<&client_policy::Bound> {
-        let port_policies = match self.policies_for_port(port) {
-            None => {
-                tracing::debug!(port, "no policies target port");
-                return None;
-            }
-            Some(policies) => policies,
-        };
-
-        for policy in port_policies.bindings.values() {
-            if policy.client_pod_selector.matches(&pod.labels) {
-                tracing::debug!(?policy, ?pod, port, "found policy for pod");
-                return Some(policy);
-            }
-        }
-
-        tracing::debug!(port, ?pod, "no policies on this port are bound to this pod");
-        None
-    }
-
-    fn policies_for_port(&self, port: NonZeroU16) -> Option<&PolicySet> {
+    pub fn policies_for_port(&self, port: NonZeroU16) -> Option<&PolicySet> {
         let port_name = self.port_names.get(&port)?;
         self.client_policies.get(port_name)
     }


### PR DESCRIPTION
This branch changes HTTPClientPolicy resources to target a specific
named port on a Service, rather than targeting the whole Service, and
updates the policy-controller indexing code to handle this.

In addition, it fixes an issue where Services don't pick up
ClientPolicies that target them if the controller saw the ClientPolicy
resource before it saw the Service. Finally, it changes the example
ClientPolicyBinding resource for clients of the `books` service to use a
label selector rather than a match expression, because the
implementation of the `NotIn` match operator in the (upstream)
policy-controller is incorrect (see linkerd/linkerd2#9433).

Here's an example lookup for the `books` Service's ClusterIP as
performed by a pod in the `webapp` Deployment:

```console
$ grpcurl -proto proto/client_policy.proto -plaintext -import-path proto -v -d '{"scheme": "http", "path":"10.43.147.28:7002", "context_token":"{\"pod\":\"webapp-95fb79ccf-lsrd7\", \"ns\":\"booksapp\"}"}' localhost:8091 io.linkerd.proxy.client_policy.ClientPolicies/GetClientPolicy

Resolved method descriptor:
// Given a destination, return the ClientPolicy that is attached to that
// destination and send an update whenever it changes.
rpc GetClientPolicy ( .io.linkerd.proxy.destination.GetDestination ) returns ( stream .io.linkerd.proxy.client_policy.ClientPolicy );

Request metadata to send:
(empty)

Response headers received:
content-type: application/grpc
date: Tue, 20 Sep 2022 19:31:14 GMT

Response contents:
{
  "fullyQualifiedName": "books.booksapp.svc.cluster.local",
  "protocol": {
    "detect": {

    }
  },
  "filters": [
    {
      "timeout": "1s"
    }
  ]
}
```